### PR TITLE
New Concept for .not()

### DIFF
--- a/src/Builder.js
+++ b/src/Builder.js
@@ -30,17 +30,21 @@ class Builder {
 
   addFilters(request, options) {
     if (Object.keys(options).length != 0) {
-      Object.keys(options).forEach(option => {
+      Object.keys(options).forEach((option) => {
         let setting = options[option]
         request.set(option, setting)
       })
     }
 
     // loop through this.queryFilters
-    this.queryFilters.forEach(queryFilter => {
+    this.queryFilters.forEach((queryFilter) => {
       switch (queryFilter.filter) {
         case 'filter':
           request.filter(queryFilter.columnName, queryFilter.operator, queryFilter.criteria)
+          break
+
+        case 'not':
+          request.not(queryFilter.columnName, queryFilter.operator, queryFilter.criteria)
           break
 
         case 'match':
@@ -68,6 +72,17 @@ class Builder {
   filter(columnName, operator, criteria) {
     this.queryFilters.push({
       filter: 'filter',
+      columnName,
+      operator,
+      criteria,
+    })
+
+    return this
+  }
+
+  not(columnName, operator, criteria) {
+    this.queryFilters.push({
+      filter: 'not',
       columnName,
       operator,
       criteria,
@@ -181,10 +196,10 @@ class Builder {
 }
 
 // pre-empts if any of the filters are used before select
-const advancedFilters = ['eq', 'gt', 'lt', 'gte', 'lte', 'like', 'ilike', 'is', 'in', 'not']
+const advancedFilters = ['eq', 'neq', 'gt', 'lt', 'gte', 'lte', 'like', 'ilike', 'is', 'in']
 
 advancedFilters.forEach(
-  operator =>
+  (operator) =>
     (Builder.prototype[operator] = function filterValue(columnName, criteria) {
       this.filter(columnName, operator, criteria)
       return this

--- a/src/Request.js
+++ b/src/Request.js
@@ -72,6 +72,22 @@ class Request extends SuperAgent {
   }
 
   /**
+   * Provides the inverse of the filter stated.
+   * @param {string} columnName The name of the column.
+   * @param {string} filter The type of filter
+   * @param { object | array | string | integer | boolean | null } criteria The value of the column to be filtered.
+   * @name filter
+   * @function
+   * @memberOf module:Filters
+   * @returns {string}
+   */
+  not(columnName, operator, criteria) {
+    let newQuery = Filters[`_${operator.toLowerCase()}`](columnName, criteria)
+    let enrichedQuery = `${newQuery.split('=')[0]}=not.${newQuery.split('=')[1]}`
+    return this.query(enrichedQuery)
+  }
+
+  /**
    * Takes a query object and translates it to a PostgREST filter query string.
    * All values are prefixed with `eq.`.
    *
@@ -80,7 +96,7 @@ class Request extends SuperAgent {
    */
 
   match(query) {
-    Object.keys(query).forEach(key => {
+    Object.keys(query).forEach((key) => {
       this.query(`${key}=eq.${query[key]}`)
     })
 
@@ -216,9 +232,9 @@ class Request extends SuperAgent {
 }
 
 // Attached all the filters
-const filters = ['eq', 'gt', 'lt', 'gte', 'lte', 'like', 'ilike', 'is', 'in', 'not']
+const filters = ['eq', 'neq', 'gt', 'lt', 'gte', 'lte', 'like', 'ilike', 'is', 'in']
 filters.forEach(
-  filter =>
+  (filter) =>
     (Request.prototype[filter] = function filterValue(columnName, criteria) {
       return this.filter(columnName, filter, criteria)
     })

--- a/src/utils/Filters.js
+++ b/src/utils/Filters.js
@@ -180,10 +180,10 @@ export function _in (columnName, filterArray) {
  * @returns {string}
  * 
  * @example
- * _not('name', 'China')
+ * _neq('name', 'China')
  * //=>
  * 'name=neq.China'
  */
-export function _not(columnName, filterValue) {
+export function _neq(columnName, filterValue) {
   return `${columnName}=neq.${filterValue}`
 }

--- a/test/integration/PostgrestClient.test.js
+++ b/test/integration/PostgrestClient.test.js
@@ -130,12 +130,12 @@ describe('PostgrestClient', () => {
 
     let readRes = await client
       .from('messages')
-      .not('username', 'supabot')
+      .neq('username', 'supabot')
       .select('*')
 
     let res = await client
       .from('messages')
-      .not('username', 'supabot')
+      .not('username', 'eq', 'supabot')
       .update({ message: 'Updated test message 2' })
 
     assert.equal(readRes.body.length, res.body.length)
@@ -156,7 +156,7 @@ describe('PostgrestClient', () => {
     let client = new PostgrestClient(rootUrl)
     let res = await client
       .from('messages')
-      .not('username', 'supabot')
+      .neq('username', 'supabot')
       .delete()
 
     await client

--- a/test/unit/Rest.test.js
+++ b/test/unit/Rest.test.js
@@ -22,25 +22,30 @@ describe('Request', () => {
 
   it('will translate match() key/values to filter', () => {
     const { _query } = new Request('GET', '/').match({ key1: 'value1', key2: 'value2' })
-    assert.deepEqual(_query, [ 'key1=eq.value1', 'key2=eq.value2' ])
+    assert.deepEqual(_query, ['key1=eq.value1', 'key2=eq.value2'])
   })
 
   it('won‘t assign to the passed match() filter', () => {
     const match = { key1: 'value1', key2: 'value2' }
     const { _query } = new Request('GET', '/').match(match)
-    assert.deepEqual(_query, [ 'key1=eq.value1', 'key2=eq.value2' ])
+    assert.deepEqual(_query, ['key1=eq.value1', 'key2=eq.value2'])
     assert.deepEqual(match, { key1: 'value1', key2: 'value2' })
+  })
+
+  it('will translate not() into  modified filter', () => {
+    const { _query } = new Request('GET', '/').not('key1', 'in', ['value1', 'value2'])
+    assert.deepEqual(_query, ['key1=not.in.(value1,value2)'])
   })
 
   it('will return a promise from end()', () => {
     const request = new Request('GET', '/')
       .end()
-      .then(x => {})
-      .catch(e => {})
+      .then((x) => {})
+      .catch((e) => {})
     assert(request instanceof Promise)
   })
 
-  it('can be resolved', done => {
+  it('can be resolved', (done) => {
     const request = new Request('GET', '/')
     Promise.resolve(request).catch(() => done())
   })


### PR DESCRIPTION
Simply put:
- The previous functionality of .not() is now .neq()
- .not() now serves a bigger function in now acting as the complete opposite to the .filter() function. .not() squeezes in the string `.not` into the final query.
- Based on [this](http://postgrest.org/en/v6.0/api.html#operators).