### PR TITLE
feat: support OR filter

### DIFF
--- a/src/Builder.js
+++ b/src/Builder.js
@@ -45,6 +45,10 @@ class Builder {
           request.not(queryFilter.columnName, queryFilter.operator, queryFilter.criteria)
           break
 
+        case 'or':
+          request.or(queryFilter.filters)
+          break
+
         case 'match':
           request.match(queryFilter.query)
           break
@@ -92,6 +96,15 @@ class Builder {
       columnName,
       operator,
       criteria,
+    })
+
+    return this
+  }
+
+  or(filters) {
+    this.queryFilters.push({
+      filter: 'or',
+      filters,
     })
 
     return this

--- a/src/Request.js
+++ b/src/Request.js
@@ -332,6 +332,7 @@ const filters = [
   'nxr',
   'nxl',
   'adj',
+  'or',
 ]
 filters.forEach(
   (filter) =>

--- a/src/utils/Filters.js
+++ b/src/utils/Filters.js
@@ -481,3 +481,19 @@ export function _nxr(columnName, filterRange) {
 export function _adj(columnName, filterRange) {
   return `${columnName}=adj.(${filterRange.join(',')})`
 }
+
+/**
+ * Finds all rows that satisfy at least one of the specified `filters`.
+ * @param {string} filters Filters to satisfy
+ * @name or
+ * @function
+ * @returns {string}
+ *
+ * @example
+ * _or('id.gt.20,and(name.eq.New Zealand,name.eq.France)')
+ * //=>
+ * 'or=(id.gt.20,and(name.eq.New Zealand,name.eq.France))'
+ */
+export function _or(filters) {
+  return `or=(${filters})`
+}

--- a/test/integration/Filters.test.js
+++ b/test/integration/Filters.test.js
@@ -211,6 +211,7 @@ describe('Filters', () => {
     'population_range=nxl.(100,500)',
     'population_range=nxr.(100,500)',
     'population_range=adj.(100,500)',
+    'or=(id.gt.20,and(name.eq.New Zealand,name.eq.France))',
   ]
 
   it('should be able to take in filters before an actual request is made', async () => {
@@ -240,11 +241,13 @@ describe('Filters', () => {
       .nxl('population_range', [100, 500])
       .nxr('population_range', [100, 500])
       .adj('population_range', [100, 500])
+      .or('id.gt.20,and(name.eq.New Zealand,name.eq.France)')
       .select('*')
 
     assert.deepEqual(response._query, expectedQueryArray)
   })
 
+  // FIXME: This is still before a request is made.
   it('should be able to take in filters after an actual request is made', async () => {
     const client = new PostgrestClient(rootUrl)
     const response = client
@@ -273,6 +276,7 @@ describe('Filters', () => {
       .nxl('population_range', [100, 500])
       .nxr('population_range', [100, 500])
       .adj('population_range', [100, 500])
+      .or('id.gt.20,and(name.eq.New Zealand,name.eq.France)')
 
     assert.deepEqual(response._query, expectedQueryArray)
   })


### PR DESCRIPTION
Adds support for OR filter like so:

```js
client.from('countries').or('id.gt.20,and(name.eq.New Zealand,name.eq.France)')
```

Support for AND is not added because they're redundant with chaining filters.

Closes #44.