### PR TITLE
fix: proper usage of isomorphic URL

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,5 +1,4 @@
 import fetch from 'isomorphic-unfetch'
-import { URL } from 'url'
 
 // https://postgrest.org/en/stable/api.html?highlight=options#errors-and-http-status-codes
 interface PostgrestError {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

postgrest-js@0.18.0 doesn't work in the browser.

## Additional context

I'm using WHATWG `URL` to build the URL + query parameters. But I used it from Node's built-in `url` module, which clearly [doesn't exist in the browser](https://codesandbox.io/s/vigilant-moon-1o4g9). Rookie mistake!

`URL` is also [available globally](https://nodejs.org/api/url.html#url_class_url) in Node, so I'm removing the import to make this work in the browser.