### PR TITLE
don't mutate headers

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -91,7 +91,7 @@ export class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
   ) {
     super({} as PostgrestBuilder<T>)
     this.url = new URL(url)
-    this.headers = headers
+    this.headers = { ...headers }
     this.schema = schema
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

When building several queries using a single PostgrestClient instance, calling `single` will break subsequent requests since the headers object it mutates is currently shared across all queries. This PR changes the behaviour so the query builder always receives a fresh headers object that is safe to mutate.

## What is the current behavior?

First request
```ts
this.data.from("properties")
    .select("*")
    .filter("id", "eq", id))
    .single()
```

Expect: JSON Object
Receive: JSON Object

Second request
```ts
this.data.from("properties")
    .select("*")
```

Expect: Result Set
Receive: Error: Results contain 3 rows, application/vnd.pgrst.object+json requires 1 row

## What is the new behavior?

No errors are observed when the two queries above are run. Each query receives its own copy of the headers object.

## Additional context

Affected versions: 0.18.x, 0.19.0
