### PR TITLE
Allow filters and transforms on insert

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -2,7 +2,7 @@ import fetch from 'cross-fetch'
 
 /**
  * Error format
- * 
+ *
  * {@link https://postgrest.org/en/stable/api.html?highlight=options#errors-and-http-status-codes}
  */
 interface PostgrestError {
@@ -12,9 +12,9 @@ interface PostgrestError {
   code: string
 }
 
-/** 
+/**
  * Response format
- * 
+ *
  * {@link https://github.com/supabase/supabase-js/issues/32}
  */
 interface PostgrestResponse<T> {
@@ -130,14 +130,14 @@ export class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
   insert(
     values: Partial<T> | Partial<T>[],
     { upsert = false, onConflict }: { upsert?: boolean; onConflict?: string } = {}
-  ): PostgrestBuilder<T> {
+  ): PostgrestFilterBuilder<T> {
     this.method = 'POST'
     this.headers['Prefer'] = upsert
       ? 'return=representation,resolution=merge-duplicates'
       : 'return=representation'
     if (upsert && onConflict !== undefined) this.url.searchParams.set('on_conflict', onConflict)
     this.body = values
-    return this
+    return new PostgrestFilterBuilder(this)
   }
 
   /**

--- a/test/__snapshots__/transforms.test.ts.snap
+++ b/test/__snapshots__/transforms.test.ts.snap
@@ -169,3 +169,25 @@ Object {
   "statusText": "OK",
 }
 `;
+
+exports[`single on insert 1`] = `
+Object {
+  "body": Object {
+    "age_range": null,
+    "catchphrase": null,
+    "data": null,
+    "status": "ONLINE",
+    "username": "foo",
+  },
+  "data": Object {
+    "age_range": null,
+    "catchphrase": null,
+    "data": null,
+    "status": "ONLINE",
+    "username": "foo",
+  },
+  "error": null,
+  "status": 201,
+  "statusText": "Created",
+}
+`;

--- a/test/transforms.test.ts
+++ b/test/transforms.test.ts
@@ -21,3 +21,10 @@ test('single', async () => {
   const res = await postgrest.from('users').select().limit(1).single()
   expect(res).toMatchSnapshot()
 })
+
+test('single on insert', async () => {
+  const res = await postgrest.from('users').insert({ username: 'foo' }).single()
+  expect(res).toMatchSnapshot()
+
+  await postgrest.from('users').delete().eq('username', 'foo')
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the new behavior?

Allow vertical filters and transforms on the result of `insert()`. E.g.:

```js
const { error, data } = await postgrest
    .from('users')
    .insert({ ... })
    .single()
```

Most of the time, we just want a single object for the above.