### PR TITLE
chore: Types improvements.

### DIFF
--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -39,7 +39,7 @@ export default class PostgrestClient {
    */
   from<T = any>(table: string): PostgrestQueryBuilder<T> {
     const url = `${this.url}/${table}`
-    return new PostgrestQueryBuilder(url, { headers: this.headers, schema: this.schema })
+    return new PostgrestQueryBuilder<T>(url, { headers: this.headers, schema: this.schema })
   }
 
   /**

--- a/src/lib/PostgrestTransformBuilder.ts
+++ b/src/lib/PostgrestTransformBuilder.ts
@@ -1,4 +1,4 @@
-import { PostgrestBuilder } from './types'
+import { PostgrestBuilder, PostgrestSingleResponse } from './types'
 
 /**
  * Post-filters (transforms)
@@ -68,8 +68,8 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
    * Retrieves only one row from the result. Result must be one row (e.g. using
    * `limit`), otherwise this will result in an error.
    */
-  single(): PostgrestTransformBuilder<T> {
+  single(): PromiseLike<PostgrestSingleResponse<T>> {
     this.headers['Accept'] = 'application/vnd.pgrst.object+json'
-    return this
+    return this as PromiseLike<PostgrestSingleResponse<T>>
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,8 +51,8 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
       | ((value: PostgrestResponse<T>) => TResult1 | PromiseLike<TResult1>)
       | undefined
       | null,
-    onrejected?: (value: any) => any
-  ): Promise<any> {
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
+  ): PromiseLike<TResult1 | TResult2> {
     // https://postgrest.org/en/stable/api.html#switching-schemas
     if (typeof this.schema === 'undefined') {
       // skip

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,25 +19,40 @@ interface PostgrestError {
  */
 interface PostgrestResponse<T> {
   error: PostgrestError | null
-  data: T | T[] | null
+  data: T[] | null
   status: number
   statusText: string
   // For backward compatibility: body === data
-  body: T | T[] | null
+  body: T[] | null
 }
 
-export abstract class PostgrestBuilder<T> implements PromiseLike<any> {
-  method!: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE'
-  url!: URL
-  headers!: { [key: string]: string }
-  schema?: string
-  body?: Partial<T> | Partial<T>[]
+export interface PostgrestSingleResponse<T> {
+  error: PostgrestError | null
+  data: T | null
+  status: number
+  statusText: string
+  // For backward compatibility: body === data
+  body: T | null
+}
+
+export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestResponse<T>> {
+  protected method!: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE'
+  protected url!: URL
+  protected headers!: { [key: string]: string }
+  protected schema?: string
+  protected body?: Partial<T> | Partial<T>[]
 
   constructor(builder: PostgrestBuilder<T>) {
     Object.assign(this, builder)
   }
 
-  then(onfulfilled?: (value: any) => any, onrejected?: (value: any) => any): Promise<any> {
+  then<TResult1 = PostgrestResponse<T>, TResult2 = never>(
+    onfulfilled?:
+      | ((value: PostgrestResponse<T>) => TResult1 | PromiseLike<TResult1>)
+      | undefined
+      | null,
+    onrejected?: (value: any) => any
+  ): Promise<any> {
     // https://postgrest.org/en/stable/api.html#switching-schemas
     if (typeof this.schema === 'undefined') {
       // skip
@@ -64,13 +79,14 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<any> {
           error = await res.json()
           data = null
         }
-        return {
+        const postgrestResponse: PostgrestResponse<T> = {
           error,
           data,
           status: res.status,
           statusText: res.statusText,
           body: data,
-        } as PostgrestResponse<T>
+        }
+        return postgrestResponse
       })
       .then(onfulfilled, onrejected)
   }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -15,12 +15,12 @@ test('stored procedure', async () => {
 
 test('custom headers', async () => {
   const postgrest = new PostgrestClient(REST_URL, { headers: { apikey: 'foo' } })
-  expect(postgrest.from('users').select().headers['apikey']).toEqual('foo')
+  expect((postgrest.from('users').select() as any).headers['apikey']).toEqual('foo')
 })
 
 test('auth', async () => {
   const postgrest = new PostgrestClient(REST_URL).auth('foo')
-  expect(postgrest.from('users').select().headers['Authorization']).toEqual('Bearer foo')
+  expect((postgrest.from('users').select() as any).headers['Authorization']).toEqual('Bearer foo')
 })
 
 test('switch schema', async () => {


### PR DESCRIPTION
r? @soedirgo @kiwicopple (I might need some help with updating the test snapshots)

## What kind of change does this PR introduce?

- Make `PostgrestResponse` data always an array
- Introduce `PostgrestSingleResponse` and make `single` return `PromiseLike<PostgrestSingleResponse<T>>`
  - This means `single` has to be called at the very end of the method chain in a TypeScript context. 
- Make sure `PostgrestResponse` is correctly assigned as the return type of `onfulfilled` callback.

## Additional context

I've tested this in a TypeScript project:
![image](https://user-images.githubusercontent.com/5748289/96709922-eec45600-13cd-11eb-991b-1fbee764547c.png)

