### PR TITLE
Fix ordering on JSON columns

### DIFF
--- a/src/lib/PostgrestTransformBuilder.ts
+++ b/src/lib/PostgrestTransformBuilder.ts
@@ -24,7 +24,7 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
     const key = typeof foreignTable === 'undefined' ? 'order' : `"${foreignTable}".order`
     this.url.searchParams.set(
       key,
-      `"${column}".${ascending ? 'asc' : 'desc'}.${nullsFirst ? 'nullsfirst' : 'nullslast'}`
+      `${column}.${ascending ? 'asc' : 'desc'}.${nullsFirst ? 'nullsfirst' : 'nullslast'}`
     )
     return this
   }

--- a/test/__snapshots__/basic.test.ts.snap
+++ b/test/__snapshots__/basic.test.ts.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`allow ordering on JSON column 1`] = `
+Array [
+  Object {
+    "age_range": "[1,2)",
+    "catchphrase": "'cat' 'fat'",
+    "data": null,
+    "status": "ONLINE",
+    "username": "supabot",
+  },
+  Object {
+    "age_range": "[25,35)",
+    "catchphrase": "'bat' 'cat'",
+    "data": null,
+    "status": "OFFLINE",
+    "username": "kiwicopple",
+  },
+  Object {
+    "age_range": "[25,35)",
+    "catchphrase": "'bat' 'rat'",
+    "data": null,
+    "status": "ONLINE",
+    "username": "awailas",
+  },
+  Object {
+    "age_range": "[20,30)",
+    "catchphrase": "'fat' 'rat'",
+    "data": null,
+    "status": "ONLINE",
+    "username": "dragarcia",
+  },
+]
+`;
+
 exports[`basic insert, update, delete basic delete 1`] = `
 Object {
   "body": Array [

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -126,3 +126,8 @@ test("don't mutate PostgrestClient.headers", async () => {
   const { error } = await postgrest.from('users').select()
   expect(error).toMatchSnapshot()
 })
+
+test("allow ordering on JSON column", async () => {
+  const { data } = await postgrest.from('users').select().order('data->something')
+  expect(data).toMatchSnapshot()
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

Previously, `order` columns wrap the column name in quotes to allow
characters like `.` without having the user wrap it manually, but this
breaks on JSON columns, so we're removing the quotes.

## Additional context

Closes #131.
