### PR TITLE
Allow Prefer: return=minimal for C(R)UD

### DIFF
--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -46,16 +46,22 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
    *
    * @param values  The values to insert.
    * @param upsert  If `true`, performs an UPSERT.
-   * @param onConflict By specifying the `on_conflict` query parameter, you can make UPSERT work on a column(s) that has a UNIQUE constraint.
+   * @param onConflict  By specifying the `on_conflict` query parameter, you can make UPSERT work on a column(s) that has a UNIQUE constraint.
+   * @param returnInserted  If `true`, return the inserted row(s) in the response.
    */
   insert(
     values: Partial<T> | Partial<T>[],
-    { upsert = false, onConflict }: { upsert?: boolean; onConflict?: string } = {}
+    {
+      upsert = false,
+      onConflict,
+      returnInserted = true,
+    }: { upsert?: boolean; onConflict?: string; returnInserted?: boolean } = {}
   ): PostgrestFilterBuilder<T> {
     this.method = 'POST'
+    const return_ = returnInserted ? 'representation' : 'minimal'
     this.headers['Prefer'] = upsert
-      ? 'return=representation,resolution=merge-duplicates'
-      : 'return=representation'
+      ? `return=${return_},resolution=merge-duplicates`
+      : `return=${return_}`
     if (upsert && onConflict !== undefined) this.url.searchParams.set('on_conflict', onConflict)
     this.body = values
     return new PostgrestFilterBuilder(this)
@@ -65,20 +71,23 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
    * Performs an UPDATE on the table.
    *
    * @param values  The values to update.
+   * @param returnUpdated  If `true`, return the updated row(s) in the response.
    */
-  update(values: Partial<T>): PostgrestFilterBuilder<T> {
+  update(values: Partial<T>, { returnUpdated = true } = {}): PostgrestFilterBuilder<T> {
     this.method = 'PATCH'
-    this.headers['Prefer'] = 'return=representation'
+    this.headers['Prefer'] = `return=${returnUpdated ? 'representation' : 'minimal'}`
     this.body = values
     return new PostgrestFilterBuilder(this)
   }
 
   /**
    * Performs a DELETE on the table.
+   *
+   * @param returnDeleted  If `true`, return the deleted row(s) in the response.
    */
-  delete(): PostgrestFilterBuilder<T> {
+  delete({ returnDeleted = true } = {}): PostgrestFilterBuilder<T> {
     this.method = 'DELETE'
-    this.headers['Prefer'] = 'return=representation'
+    this.headers['Prefer'] = `return=${returnDeleted ? 'representation' : 'minimal'}`
     return new PostgrestFilterBuilder(this)
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -74,7 +74,8 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
         let error, data
         if (res.ok) {
           error = null
-          data = await res.json()
+          const isReturnMinimal = this.headers['Prefer']?.split(',').includes('return=minimal')
+          data = isReturnMinimal ? null : await res.json()
         } else {
           error = await res.json()
           data = null

--- a/test/__snapshots__/basic.test.ts.snap
+++ b/test/__snapshots__/basic.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Prefer: return=minimal 1`] = `null`;
+
 exports[`allow ordering on JSON column 1`] = `
 Array [
   Object {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -131,3 +131,10 @@ test('allow ordering on JSON column', async () => {
   const { data } = await postgrest.from('users').select().order('data->something')
   expect(data).toMatchSnapshot()
 })
+
+test('Prefer: return=minimal', async () => {
+  const { data } = await postgrest.from('users').insert({ username: 'bar' }, { returnInserted: false })
+  expect(data).toMatchSnapshot()
+
+  await postgrest.from('users').delete().eq('username', 'bar')
+})

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -127,7 +127,7 @@ test("don't mutate PostgrestClient.headers", async () => {
   expect(error).toMatchSnapshot()
 })
 
-test("allow ordering on JSON column", async () => {
+test('allow ordering on JSON column', async () => {
   const { data } = await postgrest.from('users').select().order('data->something')
   expect(data).toMatchSnapshot()
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

`Prefer: return` header is set to `representation` by default, but this gives an error when inserting/updating/deleting on, say, a write-only table.

## What is the new behavior?

Allow the user to set it to `minimal` by setting `returnInserted`/`returnUpdated`/`returnDeleted`.

## Additional context

Closes https://github.com/supabase/postgrest-js/issues/127.

`return=minimal`/`return=representation` could be a false dichotomy here, in which case it might be better to let the user set `return` to `'minimal' | 'representation' | ...`, but this is a safe bet for now I think.
