### PR TITLE
Postgrest response types are a union of 'error' and 'data'

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,7 +17,7 @@ interface PostgrestError {
  *
  * {@link https://github.com/supabase/supabase-js/issues/32}
  */
-interface PostgrestResponseBase<T> {
+interface PostgrestResponseBase {
   status: number
   statusText: string
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,23 +17,30 @@ interface PostgrestError {
  *
  * {@link https://github.com/supabase/supabase-js/issues/32}
  */
-interface PostgrestResponse<T> {
-  error: PostgrestError | null
-  data: T[] | null
+interface PostgrestResponseBase<T> {
   status: number
   statusText: string
-  // For backward compatibility: body === data
-  body: T[] | null
 }
 
-export interface PostgrestSingleResponse<T> {
-  error: PostgrestError | null
-  data: T | null
-  status: number
-  statusText: string
-  // For backward compatibility: body === data
-  body: T | null
+interface PostgrestResponseSuccess<T> extends PostgrestResponseBase {
+  error: null
+  data: T[]
+  body: T[]
 }
+interface PostgrestResponseFailure extends PostgrestResponseBase {
+  error: PostgrestError
+  data: null
+  // For backward compatibility: body === data
+  body: null
+}
+export type PostgrestResponse<T> = PostgrestResponseSuccess<T> | PostgrestResponseFailure
+
+interface PostgrestSingleResponseSuccess<T> extends PostgrestResponseBase {
+  data: T
+  // For backward compatibility: body === data
+  body: T
+}
+export type PostgrestSingleResponse<T> = PostgrestSingleResponseSuccess<T> | PostgrestResponseFailure
 
 export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestResponse<T>> {
   protected method!: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE'


### PR DESCRIPTION
## What kind of change does this PR introduce?
A typing enhancement. The response types are not as accurate as they could be

## What is the current behavior?
A response from postgrest currently looks like
```ts
interface PostgrestResponse<T> {
  error: Error | null
  data: T | null
}
```
this means that typescript cannot infer whether we are dealing with an errored response or a successful response. For example:
```ts
const res = supabase.from('my_table').select()
if (res.error) throw new Error('something went wrong')
for (const row of res.data) { // <- typescript will give a compiler error here that `res.data` is possibly undefined
  // do something...
}
```
in this case, we _know_ that data is populated, because error is null (shown here https://github.com/supabase/postgrest-js/blob/master/src/lib/types.ts#L75-L81). The workaround is to throw a non-null assertion operator (`res.data!`) anywhere we use data, which is not ideal.

## What is the new behavior?
this snippet of code will run without any compiler errors.
```ts
const res = supabase.from('my_table').select()
if (res.error) throw new Error('something went wrong')
for (const row of res.data) {
  // do something...
}
```

## Additional context
N/A