### PR TITLE
Remove duplicate assignment of headers

### DIFF
--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -82,14 +82,15 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
     let prefersHeaders = []
     prefersHeaders.push(`return=${returning}`)
     if (upsert) prefersHeaders.push('resolution=merge-duplicates')
-    this.headers['Prefer'] = prefersHeaders.join(',')
 
     if (upsert && onConflict !== undefined) this.url.searchParams.set('on_conflict', onConflict)
     this.body = values
     if (count) {
       prefersHeaders.push(`count=${count}`)
-      this.headers['Prefer'] = prefersHeaders.join(',')
     }
+    
+    this.headers['Prefer'] = prefersHeaders.join(',')
+      
     return new PostgrestFilterBuilder(this)
   }
 
@@ -112,12 +113,11 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
     this.method = 'PATCH'
     let prefersHeaders = []
     prefersHeaders.push(`return=${returning}`)
-    this.headers['Prefer'] = prefersHeaders.join(',')
     this.body = values
     if (count) {
       prefersHeaders.push(`count=${count}`)
-      this.headers['Prefer'] = prefersHeaders.join(',')
     }
+    this.headers['Prefer'] = prefersHeaders.join(',')
     return new PostgrestFilterBuilder(this)
   }
 
@@ -136,11 +136,10 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
     this.method = 'DELETE'
     let prefersHeaders = []
     prefersHeaders.push(`return=${returning}`)
-    this.headers['Prefer'] = prefersHeaders.join(',')
     if (count) {
       prefersHeaders.push(`count=${count}`)
-      this.headers['Prefer'] = prefersHeaders.join(',')
     }
+    this.headers['Prefer'] = prefersHeaders.join(',')
     return new PostgrestFilterBuilder(this)
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tiny optimization to not set the headers twice (one call less).

## What is the current behavior?

If count is set, headers will be joined and set again

## What is the new behavior?

Headers will only be set once
