### PR TITLE
Update Type Implementation (postgrest-js side)

### DIFF
--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -1,7 +1,8 @@
 import PostgrestQueryBuilder from './lib/PostgrestQueryBuilder'
 import PostgrestTransformBuilder from './lib/PostgrestTransformBuilder'
+import { SchemaBase, TableBase } from './lib/types'
 
-export default class PostgrestClient {
+export default class PostgrestClient<Schema extends SchemaBase = SchemaBase> {
   url: string
   headers: { [key: string]: string }
   schema?: string
@@ -37,9 +38,13 @@ export default class PostgrestClient {
    *
    * @param table  The table name to operate on.
    */
-  from<T = any>(table: string): PostgrestQueryBuilder<T> {
+  from<Type extends TableBase>(table: string): PostgrestQueryBuilder<Type>
+  from<Key extends keyof Schema>(table: Key): PostgrestQueryBuilder<Schema[Key]> {
     const url = `${this.url}/${table}`
-    return new PostgrestQueryBuilder<T>(url, { headers: this.headers, schema: this.schema })
+    return new PostgrestQueryBuilder<Schema[Key]>(url, {
+      headers: this.headers,
+      schema: this.schema,
+    })
   }
 
   /**
@@ -48,10 +53,11 @@ export default class PostgrestClient {
    * @param fn  The function name to call.
    * @param params  The parameters to pass to the function call.
    */
-  rpc<T = any>(fn: string, params?: object): PostgrestTransformBuilder<T> {
+  rpc<Type extends TableBase>(fn: string, params?: object): PostgrestTransformBuilder<Type> {
     const url = `${this.url}/rpc/${fn}`
-    return new PostgrestQueryBuilder<T>(url, { headers: this.headers, schema: this.schema }).rpc(
-      params
-    )
+    return new PostgrestQueryBuilder<Type>(url, {
+      headers: this.headers,
+      schema: this.schema,
+    }).rpc(params)
   }
 }

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -2,7 +2,7 @@ import PostgrestQueryBuilder from './lib/PostgrestQueryBuilder'
 import PostgrestTransformBuilder from './lib/PostgrestTransformBuilder'
 import { SchemaBase, TableBase } from './lib/types'
 
-export default class PostgrestClient<Schema extends SchemaBase = SchemaBase> {
+export default class PostgrestClient<S extends SchemaBase = SchemaBase> {
   url: string
   headers: { [key: string]: string }
   schema?: string
@@ -38,9 +38,9 @@ export default class PostgrestClient<Schema extends SchemaBase = SchemaBase> {
    *
    * @param table  The table name to operate on.
    */
-  from<Key extends keyof Schema>(table: Key): PostgrestQueryBuilder<Schema[Key]> {
+  from<K extends keyof S>(table: K): PostgrestQueryBuilder<S[K]> {
     const url = `${this.url}/${table}`
-    return new PostgrestQueryBuilder<Schema[Key]>(url, {
+    return new PostgrestQueryBuilder<S[K]>(url, {
       headers: this.headers,
       schema: this.schema,
     })
@@ -52,9 +52,9 @@ export default class PostgrestClient<Schema extends SchemaBase = SchemaBase> {
    * @param fn  The function name to call.
    * @param params  The parameters to pass to the function call.
    */
-  rpc<Type extends TableBase>(fn: string, params?: object): PostgrestTransformBuilder<Type> {
+  rpc<T extends TableBase>(fn: string, params?: object): PostgrestTransformBuilder<T> {
     const url = `${this.url}/rpc/${fn}`
-    return new PostgrestQueryBuilder<Type>(url, {
+    return new PostgrestQueryBuilder<T>(url, {
       headers: this.headers,
       schema: this.schema,
     }).rpc(params)

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -38,7 +38,6 @@ export default class PostgrestClient<Schema extends SchemaBase = SchemaBase> {
    *
    * @param table  The table name to operate on.
    */
-  from<Type extends TableBase>(table: string): PostgrestQueryBuilder<Type>
   from<Key extends keyof Schema>(table: Key): PostgrestQueryBuilder<Schema[Key]> {
     const url = `${this.url}/${table}`
     return new PostgrestQueryBuilder<Schema[Key]>(url, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,11 @@ import PostgrestFilterBuilder from './lib/PostgrestFilterBuilder'
 import PostgrestQueryBuilder from './lib/PostgrestQueryBuilder'
 import { PostgrestBuilder, SchemaBase, TableBase } from './lib/types'
 
-export { PostgrestClient, PostgrestFilterBuilder, PostgrestQueryBuilder, PostgrestBuilder, SchemaBase, TableBase }
+export {
+  PostgrestClient,
+  PostgrestFilterBuilder,
+  PostgrestQueryBuilder,
+  PostgrestBuilder,
+  SchemaBase,
+  TableBase,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import PostgrestClient from './PostgrestClient'
 import PostgrestFilterBuilder from './lib/PostgrestFilterBuilder'
 import PostgrestQueryBuilder from './lib/PostgrestQueryBuilder'
-import { PostgrestBuilder } from './lib/types'
+import { PostgrestBuilder, SchemaBase, TableBase } from './lib/types'
 
-export { PostgrestClient, PostgrestFilterBuilder, PostgrestQueryBuilder, PostgrestBuilder }
+export { PostgrestClient, PostgrestFilterBuilder, PostgrestQueryBuilder, PostgrestBuilder, SchemaBase, TableBase }

--- a/src/lib/PostgrestFilterBuilder.ts
+++ b/src/lib/PostgrestFilterBuilder.ts
@@ -1,10 +1,12 @@
 import PostgrestTransformBuilder from './PostgrestTransformBuilder'
+import { TableBase } from './types'
 
 /**
  * Filters
  */
 
-const cleanFilterArray = <T extends Record<string, unknown>>(filter: T[keyof T][]) => filter.map((s) => `"${s}"`).join(',')
+const cleanFilterArray = <T extends TableBase>(filter: T[keyof T][]) =>
+  filter.map((s) => `"${s}"`).join(',')
 
 type FilterOperator =
   | 'eq'
@@ -30,7 +32,9 @@ type FilterOperator =
   | 'phfts'
   | 'wfts'
 
-export default class PostgrestFilterBuilder<T extends Record<string, unknown>> extends PostgrestTransformBuilder<T> {
+export default class PostgrestFilterBuilder<
+  T extends TableBase
+> extends PostgrestTransformBuilder<T> {
   /**
    * Finds all rows which doesn't satisfy the filter.
    *

--- a/src/lib/PostgrestFilterBuilder.ts
+++ b/src/lib/PostgrestFilterBuilder.ts
@@ -4,7 +4,7 @@ import PostgrestTransformBuilder from './PostgrestTransformBuilder'
  * Filters
  */
 
-const cleanFilterArray = <T>(filter: T[keyof T][]) => filter.map((s) => `"${s}"`).join(',')
+const cleanFilterArray = <T extends Record<string, unknown>>(filter: T[keyof T][]) => filter.map((s) => `"${s}"`).join(',')
 
 type FilterOperator =
   | 'eq'
@@ -30,7 +30,7 @@ type FilterOperator =
   | 'phfts'
   | 'wfts'
 
-export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
+export default class PostgrestFilterBuilder<T extends Record<string, unknown>> extends PostgrestTransformBuilder<T> {
   /**
    * Finds all rows which doesn't satisfy the filter.
    *

--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -21,7 +21,7 @@ export default class PostgrestQueryBuilder<Type extends TableBase> extends Postg
    * @param count  Count algorithm to use to count rows in a table.
    */
   select(
-    columns: '*' | keyof Type | Array<keyof Type> = '*',
+    columns: '*' | string | keyof Type | Array<keyof Type> = '*',
     {
       head = false,
       count = null,

--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -2,12 +2,12 @@ import { PostgrestBuilder, TableBase } from './types'
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 import PostgrestTransformBuilder from './PostgrestTransformBuilder'
 
-export default class PostgrestQueryBuilder<Type extends TableBase> extends PostgrestBuilder<Type> {
+export default class PostgrestQueryBuilder<T extends TableBase> extends PostgrestBuilder<T> {
   constructor(
     url: string,
     { headers = {}, schema }: { headers?: Record<string, string>; schema?: string } = {}
   ) {
-    super({} as PostgrestBuilder<Type>)
+    super({} as PostgrestBuilder<T>)
     this.url = new URL(url)
     this.headers = { ...headers }
     this.schema = schema
@@ -21,7 +21,7 @@ export default class PostgrestQueryBuilder<Type extends TableBase> extends Postg
    * @param count  Count algorithm to use to count rows in a table.
    */
   select(
-    columns: '*' | string | keyof Type | Array<keyof Type> = '*',
+    columns: '*' | string | keyof T | Array<keyof T> = '*',
     {
       head = false,
       count = null,
@@ -29,7 +29,7 @@ export default class PostgrestQueryBuilder<Type extends TableBase> extends Postg
       head?: boolean
       count?: null | 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestFilterBuilder<Type> {
+  ): PostgrestFilterBuilder<T> {
     this.method = 'GET'
 
     if (Array.isArray(columns)) {
@@ -72,7 +72,7 @@ export default class PostgrestQueryBuilder<Type extends TableBase> extends Postg
    * @param returning  By default the new record is returned. Set this to 'minimal' if you don't need this value.
    */
   insert(
-    values: Partial<Type> | Partial<Type>[],
+    values: Partial<T> | Partial<T>[],
     {
       upsert = false,
       onConflict,
@@ -84,7 +84,7 @@ export default class PostgrestQueryBuilder<Type extends TableBase> extends Postg
       returning?: 'minimal' | 'representation'
       count?: null | 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestFilterBuilder<Type> {
+  ): PostgrestFilterBuilder<T> {
     this.method = 'POST'
 
     let prefersHeaders = []
@@ -109,7 +109,7 @@ export default class PostgrestQueryBuilder<Type extends TableBase> extends Postg
    * @param returning  By default the updated record is returned. Set this to 'minimal' if you don't need this value.
    */
   update(
-    values: Partial<Type>,
+    values: Partial<T>,
     {
       returning = 'representation',
       count = null,
@@ -117,7 +117,7 @@ export default class PostgrestQueryBuilder<Type extends TableBase> extends Postg
       returning?: 'minimal' | 'representation'
       count?: null | 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestFilterBuilder<Type> {
+  ): PostgrestFilterBuilder<T> {
     this.method = 'PATCH'
     let prefersHeaders = []
     prefersHeaders.push(`return=${returning}`)
@@ -140,7 +140,7 @@ export default class PostgrestQueryBuilder<Type extends TableBase> extends Postg
   }: {
     returning?: 'minimal' | 'representation'
     count?: null | 'exact' | 'planned' | 'estimated'
-  } = {}): PostgrestFilterBuilder<Type> {
+  } = {}): PostgrestFilterBuilder<T> {
     this.method = 'DELETE'
     let prefersHeaders = []
     prefersHeaders.push(`return=${returning}`)
@@ -161,7 +161,7 @@ export default class PostgrestQueryBuilder<Type extends TableBase> extends Postg
       head?: boolean
       count?: null | 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestTransformBuilder<Type> {
+  ): PostgrestTransformBuilder<T> {
     this.method = 'POST'
     this.body = params
     if (count) {

--- a/src/lib/PostgrestTransformBuilder.ts
+++ b/src/lib/PostgrestTransformBuilder.ts
@@ -4,7 +4,7 @@ import { PostgrestBuilder, PostgrestSingleResponse } from './types'
  * Post-filters (transforms)
  */
 
-export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
+export default class PostgrestTransformBuilder<T extends Record<string, unknown>> extends PostgrestBuilder<T> {
   /**
    * Performs vertical filtering with SELECT.
    *

--- a/src/lib/PostgrestTransformBuilder.ts
+++ b/src/lib/PostgrestTransformBuilder.ts
@@ -1,10 +1,10 @@
-import { PostgrestBuilder, PostgrestSingleResponse } from './types'
+import { PostgrestBuilder, PostgrestSingleResponse, TableBase } from './types'
 
 /**
  * Post-filters (transforms)
  */
 
-export default class PostgrestTransformBuilder<T extends Record<string, unknown>> extends PostgrestBuilder<T> {
+export default class PostgrestTransformBuilder<T extends TableBase> extends PostgrestBuilder<T> {
   /**
    * Performs vertical filtering with SELECT.
    *

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,7 +54,7 @@ export type PostgrestSingleResponse<T> =
   | PostgrestSingleResponseSuccess<T>
   | PostgrestResponseFailure
 
-export abstract class PostgrestBuilder<T extends Record<string, unknown>>
+export abstract class PostgrestBuilder<T extends TableBase>
   implements PromiseLike<PostgrestResponse<T>> {
   protected method!: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE'
   protected url!: URL

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,6 @@
 import fetch from 'cross-fetch'
 
-export type TableBase = Record<string, unknown>
+export type TableBase = Record<string, any>
 
 export type SchemaBase = Record<string, TableBase>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,9 @@
 import fetch from 'cross-fetch'
 
+export type TableBase = Record<string, unknown>
+
+export type SchemaBase = Record<string, TableBase>
+
 /**
  * Error format
  *
@@ -28,6 +32,7 @@ interface PostgrestResponseSuccess<T> extends PostgrestResponseBase {
   body: T[]
   count: number | null
 }
+
 interface PostgrestResponseFailure extends PostgrestResponseBase {
   error: PostgrestError
   data: null
@@ -35,6 +40,7 @@ interface PostgrestResponseFailure extends PostgrestResponseBase {
   body: null
   count: null
 }
+
 export type PostgrestResponse<T> = PostgrestResponseSuccess<T> | PostgrestResponseFailure
 
 interface PostgrestSingleResponseSuccess<T> extends PostgrestResponseBase {
@@ -43,11 +49,13 @@ interface PostgrestSingleResponseSuccess<T> extends PostgrestResponseBase {
   // For backward compatibility: body === data
   body: T
 }
+
 export type PostgrestSingleResponse<T> =
   | PostgrestSingleResponseSuccess<T>
   | PostgrestResponseFailure
 
-export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestResponse<T>> {
+export abstract class PostgrestBuilder<T extends Record<string, unknown>>
+  implements PromiseLike<PostgrestResponse<T>> {
   protected method!: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE'
   protected url!: URL
   protected headers!: { [key: string]: string }

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -2645,6 +2645,51 @@ Object {
 }
 `;
 
+exports[`select with array columns 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "age_range": "[1,2)",
+      "username": "supabot",
+    },
+    Object {
+      "age_range": "[25,35)",
+      "username": "kiwicopple",
+    },
+    Object {
+      "age_range": "[25,35)",
+      "username": "awailas",
+    },
+    Object {
+      "age_range": "[20,30)",
+      "username": "dragarcia",
+    },
+  ],
+  "count": 4,
+  "data": Array [
+    Object {
+      "age_range": "[1,2)",
+      "username": "supabot",
+    },
+    Object {
+      "age_range": "[25,35)",
+      "username": "kiwicopple",
+    },
+    Object {
+      "age_range": "[25,35)",
+      "username": "awailas",
+    },
+    Object {
+      "age_range": "[20,30)",
+      "username": "dragarcia",
+    },
+  ],
+  "error": null,
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
 exports[`select with count:exact 1`] = `
 Object {
   "body": Array [

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -116,7 +116,7 @@ describe('types', () => {
       // eq should show User's properties in LSP/IntelliSense
       const { data: users } = await postgrest
         .from('users')
-        .select('username')
+        .select()
         .eq('username', 'supabot')
 
       // Should not error on any property

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -114,17 +114,14 @@ describe('types', () => {
   describe('without schema', () => {
     test('everything works without any types passed in', async () => {
       // eq should show User's properties in LSP/IntelliSense
-      const { data: users } = await postgrest
-        .from('users')
-        .select()
-        .eq('username', 'supabot')
+      const { data: users } = await postgrest.from('users').select().eq('username', 'supabot')
 
       // Should not error on any property
-      users?.[0].username
-      users?.[0].somethingElse
+      users[0].username
+      users[0].somethingElse
 
       // Should not error when using properties
-      const username: string = users?.[0].username
+      const username: string = users[0].username
     })
   })
 
@@ -163,15 +160,15 @@ describe('types', () => {
       const { data: users } = await typedClient.from('users').select('*').eq('username', 'supabot')
 
       // Should not error on any property
-      users?.[0].username
+      users[0].username
       // Should error on incorrect property
       // @ts-expect-error
-      users?.[0].somethingElse
+      users[0].somethingElse
 
       // Returns correct types
-      const username: string = users![0].username
+      const username: string = users[0].username
       // @ts-expect-error
-      const notUsername: number = users![0].catchphrase
+      const notUsername: number = users[0].catchphrase
     })
   })
 })
@@ -222,6 +219,11 @@ test('select with head:true, count:estimated', async () => {
 
 test('select with count:exact', async () => {
   const res = await postgrest.from('users').select('*', { count: 'exact' })
+  expect(res).toMatchSnapshot()
+})
+
+test('select with array columns', async () => {
+  const res = await postgrest.from('users').select(['username', 'age_range'], { count: 'exact' })
   expect(res).toMatchSnapshot()
 })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

A **breaking** type update, which allows easier and stricter type checking. This is a combined update for this package and `supabase-js`.

supabase/supabase-js#125

## What is the current behavior?

- You have to pass the object you're working on into `.from<User>('users')` every time you use it.
- `.select()` does not have any intellisense help.

## What is the new behavior?

You get intellisense suggestions in `.select()`.

---

You now pass the schema into the `PostgrestClient`, and let the types handle the rest from there.

The schema type is based on what `openapi-typescript` generates, as recommended in [the supabase guide](https://supabase.io/docs/client/generating-types) (which also has to be updated as the tool has renamed).

```ts
type User = {
  username: string
  data: object | null
  age_range: string | null
  status: 'ONLINE' | 'OFFLINE'
  catchphrase: 'string' | null
}

type Schema = {
  users: User
}

const supabase = new PostgrestClient<Schema>(REST_URL)

// Incorrect table, column names will result in type errors
typedClient.from('users').select('username').eq('username', 'supabot')

// Error
typedClient.from('uesrs').select('username').eq('username', 'wooo')
typedClient.from('users').select('username').eq('not_in_table', 'wooo')
```

## Additional context

Not passing in a type still works as before, with any names working and returning `any`.

I tried very hard to not make this a breaking change, by still allowing `.from<Object>()`, but it's sadly impossible without some crazy workarounds. 😢 

This package will have to be released before `supabase-js` so #123 can be updated to use the new version.
