### PR TITLE
fix: rpc method

### DIFF
--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -56,7 +56,6 @@ export default class PostgrestClient {
     count = null,
   }: {
     isVoid?: boolean,
-    head?: boolean
     count?: null | 'exact' | 'planned' | 'estimated'
   } = {}): PostgrestTransformBuilder<T> {
     const url = `${this.url}/rpc/${fn}`

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -49,12 +49,10 @@ export default class PostgrestClient {
    * @param fn  The function name to call.
    * @param params  The parameters to pass to the function call.
    * @param isVoid  Support void function
-   * @param head  When set to true, select will void data.
    * @param count  Count algorithm to use to count rows in a table.
    */
   rpc<T = any>(fn: string, params?: object, {
     isVoid = false,
-    head = false,
     count = null,
   }: {
     isVoid?: boolean,
@@ -64,7 +62,7 @@ export default class PostgrestClient {
     const url = `${this.url}/rpc/${fn}`
     const headers = isVoid ? {...this.headers, 'Prefer': 'return=minimal'} : this.headers
     return new PostgrestRpcBuilder<T>(url, { headers, schema: this.schema }).rpc(
-      params, {head, count}
+      params, {count}
     )
   }
 }

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -48,6 +48,9 @@ export default class PostgrestClient {
    *
    * @param fn  The function name to call.
    * @param params  The parameters to pass to the function call.
+   * @param isVoid  Support void function
+   * @param head  When set to true, select will void data.
+   * @param count  Count algorithm to use to count rows in a table.
    */
   rpc<T = any>(fn: string, params?: object, {
     isVoid = false,

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -1,4 +1,5 @@
 import PostgrestQueryBuilder from './lib/PostgrestQueryBuilder'
+import PostgrestRpcBuilder from './lib/PostgrestRpcBuilder'
 import PostgrestTransformBuilder from './lib/PostgrestTransformBuilder'
 
 export default class PostgrestClient {
@@ -59,7 +60,7 @@ export default class PostgrestClient {
   } = {}): PostgrestTransformBuilder<T> {
     const url = `${this.url}/rpc/${fn}`
     const headers = isVoid ? {...this.headers, 'Prefer': 'return=minimal'} : this.headers
-    return new PostgrestQueryBuilder<T>(url, { headers, schema: this.schema }).rpc(
+    return new PostgrestRpcBuilder<T>(url, { headers, schema: this.schema }).rpc(
       params, {head, count}
     )
   }

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -50,14 +50,19 @@ export default class PostgrestClient {
    * @param params  The parameters to pass to the function call.
    * @param count  Count algorithm to use to count rows in a table.
    */
-  rpc<T = any>(fn: string, params?: object, {
-    count = null,
-  }: {
-    count?: null | 'exact' | 'planned' | 'estimated'
-  } = {}): PostgrestTransformBuilder<T> {
+  rpc<T = any>(
+    fn: string,
+    params?: object,
+    {
+      count = null,
+    }: {
+      count?: null | 'exact' | 'planned' | 'estimated'
+    } = {}
+  ): PostgrestTransformBuilder<T> {
     const url = `${this.url}/rpc/${fn}`
-    return new PostgrestRpcBuilder<T>(url, { headers: this.headers, schema: this.schema }).rpc(
-      params, {count}
-    )
+    return new PostgrestRpcBuilder<T>(url, {
+      headers: this.headers,
+      schema: this.schema,
+    }).rpc(params, { count })
   }
 }

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -48,10 +48,12 @@ export default class PostgrestClient {
    * @param fn  The function name to call.
    * @param params  The parameters to pass to the function call.
    */
-  rpc<T = any>(fn: string, params?: object, isVoid?:boolean, {
+  rpc<T = any>(fn: string, params?: object, {
+    isVoid = false,
     head = false,
     count = null,
   }: {
+    isVoid?: boolean,
     head?: boolean
     count?: null | 'exact' | 'planned' | 'estimated'
   } = {}): PostgrestTransformBuilder<T> {

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -48,19 +48,15 @@ export default class PostgrestClient {
    *
    * @param fn  The function name to call.
    * @param params  The parameters to pass to the function call.
-   * @param isVoid  Support void function
    * @param count  Count algorithm to use to count rows in a table.
    */
   rpc<T = any>(fn: string, params?: object, {
-    isVoid = false,
     count = null,
   }: {
-    isVoid?: boolean,
     count?: null | 'exact' | 'planned' | 'estimated'
   } = {}): PostgrestTransformBuilder<T> {
     const url = `${this.url}/rpc/${fn}`
-    const headers = isVoid ? {...this.headers, 'Prefer': 'return=minimal'} : this.headers
-    return new PostgrestRpcBuilder<T>(url, { headers, schema: this.schema }).rpc(
+    return new PostgrestRpcBuilder<T>(url, { headers: this.headers, schema: this.schema }).rpc(
       params, {count}
     )
   }

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -48,10 +48,17 @@ export default class PostgrestClient {
    * @param fn  The function name to call.
    * @param params  The parameters to pass to the function call.
    */
-  rpc<T = any>(fn: string, params?: object): PostgrestTransformBuilder<T> {
+  rpc<T = any>(fn: string, params?: object, isVoid?:boolean, {
+    head = false,
+    count = null,
+  }: {
+    head?: boolean
+    count?: null | 'exact' | 'planned' | 'estimated'
+  } = {}): PostgrestTransformBuilder<T> {
     const url = `${this.url}/rpc/${fn}`
-    return new PostgrestQueryBuilder<T>(url, { headers: this.headers, schema: this.schema }).rpc(
-      params
+    const headers = isVoid ? {...this.headers, 'Prefer': 'return=minimal'} : this.headers
+    return new PostgrestQueryBuilder<T>(url, { headers, schema: this.schema }).rpc(
+      params, {head, count}
     )
   }
 }

--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -1,6 +1,5 @@
 import { PostgrestBuilder } from './types'
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
-import PostgrestTransformBuilder from './PostgrestTransformBuilder'
 
 export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
   constructor(
@@ -141,27 +140,5 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
     }
     this.headers['Prefer'] = prefersHeaders.join(',')
     return new PostgrestFilterBuilder(this)
-  }
-
-  /** @internal */
-  rpc(
-    params?: object,
-    {
-      head = false,
-      count = null,
-    }: {
-      head?: boolean
-      count?: null | 'exact' | 'planned' | 'estimated'
-    } = {}
-  ): PostgrestTransformBuilder<T> {
-    this.method = 'POST'
-    this.body = params
-    if (count) {
-      this.headers['Prefer'] = `count=${count}`
-    }
-    if (head) {
-      this.method = 'HEAD'
-    }
-    return new PostgrestTransformBuilder(this)
   }
 }

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -1,0 +1,25 @@
+import { PostgrestBuilder } from './types'
+import PostgrestTransformBuilder from './PostgrestTransformBuilder'
+
+export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
+  rpc(
+    params?: object,
+    {
+      head = false,
+      count = null,
+    }: {
+      head?: boolean
+      count?: null | 'exact' | 'planned' | 'estimated'
+    } = {}
+  ): PostgrestTransformBuilder<T> {
+    this.method = 'POST'
+    this.body = params
+    if (count) {
+      this.headers['Prefer'] = `count=${count}`
+    }
+    if (head) {
+      this.method = 'HEAD'
+    }
+    return new PostgrestTransformBuilder(this)
+  }
+}

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -15,22 +15,19 @@ export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
   rpc(
     params?: object,
     {
-      head = false,
       count = null,
     }: {
-      head?: boolean
       count?: null | 'exact' | 'planned' | 'estimated'
     } = {}
   ): PostgrestTransformBuilder<T> {
     this.method = 'POST'
     this.body = params
+
     if (count) {
       if (this.headers['Prefer'] !== undefined) this.headers['Prefer'] += `,count=${count}`
       else this.headers['Prefer'] = `count=${count}`
     }
-    if (head) {
-      this.method = 'HEAD'
-    }
+    
     return new PostgrestTransformBuilder(this)
   }
 }

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -2,6 +2,16 @@ import { PostgrestBuilder } from './types'
 import PostgrestTransformBuilder from './PostgrestTransformBuilder'
 
 export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
+  constructor(
+    url: string,
+    { headers = {}, schema }: { headers?: { [key: string]: string }; schema?: string } = {}
+  ) {
+    super({} as PostgrestBuilder<T>)
+    this.url = new URL(url)
+    this.headers = { ...headers }
+    this.schema = schema
+  }
+  
   rpc(
     params?: object,
     {

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -15,7 +15,8 @@ export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
     this.method = 'POST'
     this.body = params
     if (count) {
-      this.headers['Prefer'] = `count=${count}`
+      if (this.headers['Prefer'] !== undefined) this.headers['Prefer'] += `,count=${count}`
+      else this.headers['Prefer'] = `count=${count}`
     }
     if (head) {
       this.method = 'HEAD'

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -11,7 +11,7 @@ export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
     this.headers = { ...headers }
     this.schema = schema
   }
-  
+
   rpc(
     params?: object,
     {
@@ -27,7 +27,7 @@ export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
       if (this.headers['Prefer'] !== undefined) this.headers['Prefer'] += `,count=${count}`
       else this.headers['Prefer'] = `count=${count}`
     }
-    
+
     return new PostgrestTransformBuilder(this)
   }
 }

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -12,6 +12,9 @@ export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
     this.schema = schema
   }
 
+  /**
+   * Perform a stored procedure call.
+   */
   rpc(
     params?: object,
     {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -91,13 +91,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
           const isReturnMinimal = this.headers['Prefer']?.split(',').includes('return=minimal')
           if (this.method !== 'HEAD' && !isReturnMinimal) {
             const text = await res.text()
-            if (text && text !== '') {
-              try {
-                data = JSON.parse(text)
-              } catch (_) {
-                error = { message: 'Failed to parse json response' }
-              }
-            }
+            if (text && text !== '') data = JSON.parse(text)
           }
 
           const countHeader = this.headers['Prefer']?.match(/count=(exact|planned|estimated)/)
@@ -106,12 +100,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
             count = parseInt(contentRange[1])
           }
         } else {
-          const text = await res.text()
-          try {
-            error = JSON.parse(text)
-          } catch (_) {
-            error = { message: text }
-          }
+          error = await res.json()
         }
 
         const postgrestResponse: PostgrestResponse<T> = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -94,7 +94,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
             if (text && text !== '') {
               try {
                 data = JSON.parse(text)
-              } catch (err) {
+              } catch (_) {
                 error = { message: 'Failed to parse json response' }
               }
             }
@@ -109,7 +109,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
           const text = await res.text()
           try {
             error = JSON.parse(text)
-          } catch (err) {
+          } catch (_) {
             error = { message: text }
           }
         }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -83,32 +83,37 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
       body: JSON.stringify(this.body),
     })
       .then(async (res) => {
-        let error, data, count
+        let error = null
+        let data = null
+        let count = null
+
         if (res.ok) {
-          error = null
-          if (this.method !== 'HEAD') {
-            const isReturnMinimal = this.headers['Prefer']?.split(',').includes('return=minimal')
-            data = isReturnMinimal ? null : await res.json()
-          } else {
-            data = null
+          const isReturnMinimal = this.headers['Prefer']?.split(',').includes('return=minimal')
+          if (this.method !== 'HEAD' && !isReturnMinimal) {
+            const text = await res.text()
+            if (text && text !== '') {
+              try {
+                data = JSON.parse(text)
+              } catch (err) {
+                error = { message: 'Failed to parse json response' }
+              }
+            }
           }
 
           const countHeader = this.headers['Prefer']?.match(/count=(exact|planned|estimated)/)
-          if (countHeader) {
-            const contentRange = res.headers.get('content-range')?.split('/')
-            if (contentRange && contentRange.length > 1) {
-              count = parseInt(contentRange[1])
-            } else {
-              count = null
-            }
-          } else {
-            count = null
+          const contentRange = res.headers.get('content-range')?.split('/')
+          if (countHeader && contentRange && contentRange.length > 1) {
+            count = parseInt(contentRange[1])
           }
         } else {
-          error = await res.json()
-          data = null
-          count = null
+          const text = await res.text()
+          try {
+            error = JSON.parse(text)
+          } catch (err) {
+            error = { message: text }
+          }
         }
+
         const postgrestResponse: PostgrestResponse<T> = {
           error,
           data,

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -2885,33 +2885,12 @@ Object {
 
 exports[`stored procedure with count: 'exact' 1`] = `
 Object {
-  "body": null,
-  "count": null,
-  "data": null,
-  "error": Object {
-    "code": "42883",
-    "details": null,
-    "hint": "No function matches the given name and argument types. You might need to add explicit type casts.",
-    "message": "function public.get_status(count => text, name_param => text) does not exist",
-  },
-  "status": 404,
-  "statusText": "Not Found",
-}
-`;
-
-exports[`stored procedure with count: 'exact', head: true 1`] = `
-Object {
-  "body": null,
-  "count": null,
-  "data": null,
-  "error": Object {
-    "code": "42883",
-    "details": null,
-    "hint": "No function matches the given name and argument types. You might need to add explicit type casts.",
-    "message": "function public.get_status(count => text, head => text, name_param => text) does not exist",
-  },
-  "status": 404,
-  "statusText": "Not Found",
+  "body": "ONLINE",
+  "count": 1,
+  "data": "ONLINE",
+  "error": null,
+  "status": 200,
+  "statusText": "OK",
 }
 `;
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -2883,6 +2883,17 @@ Object {
 }
 `;
 
+exports[`stored procedure returns void 1`] = `
+Object {
+  "body": null,
+  "count": null,
+  "data": null,
+  "error": null,
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
 exports[`stored procedure with count: 'exact' 1`] = `
 Object {
   "body": "ONLINE",

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -13,6 +13,11 @@ test('stored procedure', async () => {
   expect(res).toMatchSnapshot()
 })
 
+test('stored procedure returns void', async () => {
+  const res = await postgrest.rpc('void_func')
+  expect(res).toMatchSnapshot()
+})
+
 test('custom headers', async () => {
   const postgrest = new PostgrestClient(REST_URL, { headers: { apikey: 'foo' } })
   expect((postgrest.from('users').select() as any).headers['apikey']).toEqual('foo')

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -175,14 +175,6 @@ test("stored procedure with count: 'exact'", async () => {
   expect(res).toMatchSnapshot()
 })
 
-test("stored procedure with count: 'exact', head: true", async () => {
-  const res = await postgrest.rpc('get_status', { name_param: 'supabot' }, {
-    count: 'exact',
-    head: true,
-  })
-  expect(res).toMatchSnapshot()
-})
-
 describe("insert, update, delete with count: 'exact'", () => {
   test("insert with count: 'exact'", async () => {
     let res = await postgrest

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -171,13 +171,12 @@ test('select with count:exact', async () => {
 })
 
 test("stored procedure with count: 'exact'", async () => {
-  const res = await postgrest.rpc('get_status', { name_param: 'supabot', count: 'exact' })
+  const res = await postgrest.rpc('get_status', { name_param: 'supabot'}, {count: 'exact' })
   expect(res).toMatchSnapshot()
 })
 
 test("stored procedure with count: 'exact', head: true", async () => {
-  const res = await postgrest.rpc('get_status', {
-    name_param: 'supabot',
+  const res = await postgrest.rpc('get_status', { name_param: 'supabot' }, {
     count: 'exact',
     head: true,
   })

--- a/test/db/00-schema.sql
+++ b/test/db/00-schema.sql
@@ -47,6 +47,10 @@ RETURNS TABLE(username text, status user_status) AS $$
   SELECT username, status from users WHERE username=name_param;
 $$ LANGUAGE SQL IMMUTABLE;
 
+CREATE FUNCTION public.void_func() 
+RETURNS void AS $$
+$$ LANGUAGE SQL;
+
 -- SECOND SCHEMA USERS
 CREATE TYPE personal.user_status AS ENUM ('ONLINE', 'OFFLINE');
 CREATE TABLE personal.users(


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Create PostgrestRpcBuilder
- Move `rpc` method from PostgrestQueryBuilder to PostgrestRpcBuilder
- Fixes `PostgrestClient.rpc()` options param 
- Improve fetch response + error parsing (fixes https://github.com/supabase/supabase-js/issues/132)
- Fixes stored procedure unit tests

## What is the current behavior?

- When `rpc` method insides PostgrestQueryBuilder. User can create this chain
`let res = await postgrest.from('users').rpc({ name_param: 'supabot'})` 
It's wrong.
- no way to set options param
<img width="490" alt="Screenshot 2021-02-22 at 10 14 38 AM" src="https://user-images.githubusercontent.com/689843/108648688-d8064b00-74f6-11eb-92f4-dd2c1b898c00.png">

## What is the new behavior?

- No breaking change. `postgrest.rpc` usage is the same after moving it to PostgrestRpcBuilder
- Expose `rpc` options param
<img width="479" alt="Screenshot 2021-02-23 at 9 27 46 AM" src="https://user-images.githubusercontent.com/689843/108791173-6c38e680-75b9-11eb-86f1-544e1c4b5e41.png">

