### PR TITLE
support embedded or filter

### DIFF
--- a/src/lib/PostgrestFilterBuilder.ts
+++ b/src/lib/PostgrestFilterBuilder.ts
@@ -47,9 +47,11 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * Finds all rows satisfying at least one of the filters.
    *
    * @param filters  The filters to use, separated by commas.
+   * @param foreignTable  The foreign table to use (if `column` is a foreign column).
    */
-  or(filters: string): this {
-    this.url.searchParams.append('or', `(${filters})`)
+  or(filters: string, { foreignTable }: { foreignTable?: string } = {}): this {
+    const key = typeof foreignTable === 'undefined' ? 'or' : `${foreignTable}.or`
+    this.url.searchParams.append(key, `(${filters})`)
     return this
   }
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -790,6 +790,140 @@ Object {
 }
 `;
 
+exports[`embedded filters embedded or 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "messages": Array [
+        Object {
+          "channel_id": 1,
+          "data": null,
+          "id": 1,
+          "message": "Hello World 👋",
+          "username": "supabot",
+        },
+        Object {
+          "channel_id": 2,
+          "data": null,
+          "id": 2,
+          "message": "Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.",
+          "username": "supabot",
+        },
+      ],
+    },
+    Object {
+      "messages": Array [],
+    },
+    Object {
+      "messages": Array [],
+    },
+    Object {
+      "messages": Array [],
+    },
+  ],
+  "count": null,
+  "data": Array [
+    Object {
+      "messages": Array [
+        Object {
+          "channel_id": 1,
+          "data": null,
+          "id": 1,
+          "message": "Hello World 👋",
+          "username": "supabot",
+        },
+        Object {
+          "channel_id": 2,
+          "data": null,
+          "id": 2,
+          "message": "Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.",
+          "username": "supabot",
+        },
+      ],
+    },
+    Object {
+      "messages": Array [],
+    },
+    Object {
+      "messages": Array [],
+    },
+    Object {
+      "messages": Array [],
+    },
+  ],
+  "error": null,
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
+exports[`embedded filters embedded or with and 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "messages": Array [
+        Object {
+          "channel_id": 1,
+          "data": null,
+          "id": 1,
+          "message": "Hello World 👋",
+          "username": "supabot",
+        },
+        Object {
+          "channel_id": 2,
+          "data": null,
+          "id": 2,
+          "message": "Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.",
+          "username": "supabot",
+        },
+      ],
+    },
+    Object {
+      "messages": Array [],
+    },
+    Object {
+      "messages": Array [],
+    },
+    Object {
+      "messages": Array [],
+    },
+  ],
+  "count": null,
+  "data": Array [
+    Object {
+      "messages": Array [
+        Object {
+          "channel_id": 1,
+          "data": null,
+          "id": 1,
+          "message": "Hello World 👋",
+          "username": "supabot",
+        },
+        Object {
+          "channel_id": 2,
+          "data": null,
+          "id": 2,
+          "message": "Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.",
+          "username": "supabot",
+        },
+      ],
+    },
+    Object {
+      "messages": Array [],
+    },
+    Object {
+      "messages": Array [],
+    },
+    Object {
+      "messages": Array [],
+    },
+  ],
+  "error": null,
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
 exports[`embedded select 1`] = `
 Object {
   "body": Array [

--- a/test/resource-embedding.ts
+++ b/test/resource-embedding.ts
@@ -13,6 +13,20 @@ describe('embedded filters', () => {
     const res = await postgrest.from('users').select('messages(*)').eq('messages.channel_id', 1)
     expect(res).toMatchSnapshot()
   })
+  test('embedded or', async () => {
+    const res = await postgrest
+      .from('users')
+      .select('messages(*)')
+      .or('channel_id.eq.2,message.eq.Hello World 👋', { foreignTable: 'messages' })
+    expect(res).toMatchSnapshot()
+  })
+  test('embedded or with and', async () => {
+    const res = await postgrest
+      .from('users')
+      .select('messages(*)')
+      .or('channel_id.eq.2,and(message.eq.Hello World 👋,username.eq.supabot)', { foreignTable: 'messages' })
+    expect(res).toMatchSnapshot()
+  })
 })
 
 describe('embedded transforms', () => {


### PR DESCRIPTION
# Embedded filters

Postgrest supports embedded filters through the following syntax https://postgrest.org/en/v7.0.0/api.html#embedded-filters

## Use case

Filtering a sub selection in postgres with `or`/`and` for the foreignTable.

Required workaround query param format based on an extended version of the supabase todos example:

```js
const start = new Date().toISOString();
const end = new Date().toISOString();

const workaroundParam = `todos.or=(completed_at.is.null,and(completed_at.gte.${start},completed_at.lt.${end}))`

await client
.from(`projects?${workaroundParam}`)
.select('id,todos(id,completed_at)')
.eq('id', 1)
.order('inserted_at', { foreignTable: "todos", ascending: false });
```

## Solution

Update the or filter to support foreignTable handling to achieve the desired output of postgrest which doesn't require hacking it into the from statement.

```js
const start = new Date().toISOString();
const end = new Date().toISOString();

await client
.from(`projects`)
.select('id,todos(id,completed_at)')
.eq('id', 1)
.or(`completed_at.is.null,and(completed_at.gte.${start},completed_at.lt.${end})`, { foreignTable: 'todos' })
.order('inserted_at', { foreignTable: "todos", ascending: false });
```