### PR TITLE
support multliple column order

### DIFF
--- a/src/lib/PostgrestTransformBuilder.ts
+++ b/src/lib/PostgrestTransformBuilder.ts
@@ -46,9 +46,13 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
     }: { ascending?: boolean; nullsFirst?: boolean; foreignTable?: string } = {}
   ): this {
     const key = typeof foreignTable === 'undefined' ? 'order' : `${foreignTable}.order`
+    const existingOrder = this.url.searchParams.get(key)
+
     this.url.searchParams.set(
       key,
-      `${column}.${ascending ? 'asc' : 'desc'}.${nullsFirst ? 'nullsfirst' : 'nullslast'}`
+      `${existingOrder ? `${existingOrder},` : ''}${column}.${ascending ? 'asc' : 'desc'}.${
+        nullsFirst ? 'nullsfirst' : 'nullslast'
+      }`
     )
     return this
   }

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1111,6 +1111,73 @@ Object {
 }
 `;
 
+exports[`embedded transforms embedded order on multiple columns 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "messages": Array [
+        Object {
+          "channel_id": 2,
+          "data": null,
+          "id": 2,
+          "message": "Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.",
+          "username": "supabot",
+        },
+        Object {
+          "channel_id": 1,
+          "data": null,
+          "id": 1,
+          "message": "Hello World 👋",
+          "username": "supabot",
+        },
+      ],
+    },
+    Object {
+      "messages": Array [],
+    },
+    Object {
+      "messages": Array [],
+    },
+    Object {
+      "messages": Array [],
+    },
+  ],
+  "count": null,
+  "data": Array [
+    Object {
+      "messages": Array [
+        Object {
+          "channel_id": 2,
+          "data": null,
+          "id": 2,
+          "message": "Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.",
+          "username": "supabot",
+        },
+        Object {
+          "channel_id": 1,
+          "data": null,
+          "id": 1,
+          "message": "Hello World 👋",
+          "username": "supabot",
+        },
+      ],
+    },
+    Object {
+      "messages": Array [],
+    },
+    Object {
+      "messages": Array [],
+    },
+    Object {
+      "messages": Array [],
+    },
+  ],
+  "error": null,
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
 exports[`embedded transforms embedded range 1`] = `
 Object {
   "body": Array [
@@ -2583,6 +2650,47 @@ Object {
       "data": null,
       "status": "ONLINE",
       "username": "awailas",
+    },
+  ],
+  "error": null,
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
+exports[`order on multiple columns 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "channel_id": 2,
+      "data": null,
+      "id": 2,
+      "message": "Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.",
+      "username": "supabot",
+    },
+    Object {
+      "channel_id": 1,
+      "data": null,
+      "id": 1,
+      "message": "Hello World 👋",
+      "username": "supabot",
+    },
+  ],
+  "count": null,
+  "data": Array [
+    Object {
+      "channel_id": 2,
+      "data": null,
+      "id": 2,
+      "message": "Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.",
+      "username": "supabot",
+    },
+    Object {
+      "channel_id": 1,
+      "data": null,
+      "id": 1,
+      "message": "Hello World 👋",
+      "username": "supabot",
     },
   ],
   "error": null,

--- a/test/resource-embedding.ts
+++ b/test/resource-embedding.ts
@@ -38,6 +38,15 @@ describe('embedded transforms', () => {
     expect(res).toMatchSnapshot()
   })
 
+test('embedded order on multiple columns', async () => {
+    const res = await postgrest
+      .from('users')
+      .select('messages(*)')
+      .order('channel_id', { foreignTable: 'messages', ascending: false })
+      .order('username', { foreignTable: 'messages', ascending: false })
+  expect(res).toMatchSnapshot()
+})
+
   test('embedded limit', async () => {
     const res = await postgrest
       .from('users')

--- a/test/transforms.ts
+++ b/test/transforms.ts
@@ -7,6 +7,15 @@ test('order', async () => {
   expect(res).toMatchSnapshot()
 })
 
+test('order on multiple columns', async () => {
+  const res = await postgrest
+    .from('messages')
+    .select()
+    .order('channel_id', { ascending: false })
+    .order('username', { ascending: false })
+  expect(res).toMatchSnapshot()
+})
+
 test('limit', async () => {
   const res = await postgrest.from('users').select().limit(1)
   expect(res).toMatchSnapshot()


### PR DESCRIPTION
## Order by multiple columns

Adds support to order by more than a single column in both embedded table and top level columns as per postgrest https://postgrest.org/en/v7.0.0/api.html?highlight=order#ordering.

## What is the current behavior?

Overwrites the single order param only allowing the latest in the call chain to resolve.

## What is the new behavior?

Appends order clauses comma delimited for the query instance.