### PR TITLE
Make UPSERT its own function

### DIFF
--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -78,8 +78,7 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
   ): PostgrestFilterBuilder<T> {
     this.method = 'POST'
 
-    let prefersHeaders = []
-    prefersHeaders.push(`return=${returning}`)
+    const prefersHeaders = [`return=${returning}`]
     if (upsert) prefersHeaders.push('resolution=merge-duplicates')
 
     if (upsert && onConflict !== undefined) this.url.searchParams.set('on_conflict', onConflict)
@@ -98,6 +97,7 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
    *
    * @param values  The values to update.
    * @param returning  By default the updated record is returned. Set this to 'minimal' if you don't need this value.
+   * @param count  Count algorithm to use to count rows in a table.
    */
   update(
     values: Partial<T>,
@@ -110,8 +110,7 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
     } = {}
   ): PostgrestFilterBuilder<T> {
     this.method = 'PATCH'
-    let prefersHeaders = []
-    prefersHeaders.push(`return=${returning}`)
+    const prefersHeaders = [`return=${returning}`]
     this.body = values
     if (count) {
       prefersHeaders.push(`count=${count}`)
@@ -124,6 +123,7 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
    * Performs a DELETE on the table.
    *
    * @param returning  If `true`, return the deleted row(s) in the response.
+   * @param count  Count algorithm to use to count rows in a table.
    */
   delete({
     returning = 'representation',
@@ -133,8 +133,7 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
     count?: null | 'exact' | 'planned' | 'estimated'
   } = {}): PostgrestFilterBuilder<T> {
     this.method = 'DELETE'
-    let prefersHeaders = []
-    prefersHeaders.push(`return=${returning}`)
+    const prefersHeaders = [`return=${returning}`]
     if (count) {
       prefersHeaders.push(`count=${count}`)
     }

--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -87,9 +87,9 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
     if (count) {
       prefersHeaders.push(`count=${count}`)
     }
-    
+
     this.headers['Prefer'] = prefersHeaders.join(',')
-      
+
     return new PostgrestFilterBuilder(this)
   }
 

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -37,7 +37,7 @@ test('switch schema', async () => {
 test('on_conflict insert', async () => {
   const res = await postgrest
     .from('users')
-    .insert({ username: 'dragarcia' }, { upsert: true, onConflict: 'username' })
+    .upsert({ username: 'dragarcia' }, { onConflict: 'username' })
   expect(res).toMatchSnapshot()
 })
 
@@ -55,7 +55,7 @@ describe('basic insert, update, delete', () => {
   test('upsert', async () => {
     let res = await postgrest
       .from('messages')
-      .insert({ id: 3, message: 'foo', username: 'supabot', channel_id: 2 }, { upsert: true })
+      .upsert({ id: 3, message: 'foo', username: 'supabot', channel_id: 2 })
     expect(res).toMatchSnapshot()
 
     res = await postgrest.from('messages').select()
@@ -194,10 +194,7 @@ describe("insert, update, delete with count: 'exact'", () => {
   test("upsert with count: 'exact'", async () => {
     let res = await postgrest
       .from('messages')
-      .insert(
-        { id: 3, message: 'foo', username: 'supabot', channel_id: 2 },
-        { upsert: true, count: 'exact' }
-      )
+      .upsert({ id: 3, message: 'foo', username: 'supabot', channel_id: 2 }, { count: 'exact' })
     expect(res).toMatchSnapshot()
 
     res = await postgrest.from('messages').select()

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -176,7 +176,7 @@ test('select with count:exact', async () => {
 })
 
 test("stored procedure with count: 'exact'", async () => {
-  const res = await postgrest.rpc('get_status', { name_param: 'supabot'}, {count: 'exact' })
+  const res = await postgrest.rpc('get_status', { name_param: 'supabot' }, { count: 'exact' })
   expect(res).toMatchSnapshot()
 })
 

--- a/test/resource-embedding.ts
+++ b/test/resource-embedding.ts
@@ -24,7 +24,9 @@ describe('embedded filters', () => {
     const res = await postgrest
       .from('users')
       .select('messages(*)')
-      .or('channel_id.eq.2,and(message.eq.Hello World 👋,username.eq.supabot)', { foreignTable: 'messages' })
+      .or('channel_id.eq.2,and(message.eq.Hello World 👋,username.eq.supabot)', {
+        foreignTable: 'messages',
+      })
     expect(res).toMatchSnapshot()
   })
 })
@@ -38,14 +40,14 @@ describe('embedded transforms', () => {
     expect(res).toMatchSnapshot()
   })
 
-test('embedded order on multiple columns', async () => {
+  test('embedded order on multiple columns', async () => {
     const res = await postgrest
       .from('users')
       .select('messages(*)')
       .order('channel_id', { foreignTable: 'messages', ascending: false })
       .order('username', { foreignTable: 'messages', ascending: false })
-  expect(res).toMatchSnapshot()
-})
+    expect(res).toMatchSnapshot()
+  })
 
   test('embedded limit', async () => {
     const res = await postgrest


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

UPSERT is done through `insert()`, which might confuse some users.

## What is the new behavior?

Make UPSERT its own function.

## Additional context

Closes #161.
