### PR TITLE
fix: include `columns` param on bulk INSERT

### DIFF
--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -107,6 +107,12 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
 
     this.headers['Prefer'] = prefersHeaders.join(',')
 
+    if (Array.isArray(values)) {
+      const columns = values.reduce((acc, x) => acc.concat(Object.keys(x)), [] as string[])
+      const uniqueColumns = [...new Set(columns)]
+      this.url.searchParams.set('columns', uniqueColumns.join(','))
+    }
+
     return new PostgrestFilterBuilder(this)
   }
 

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -234,3 +234,8 @@ describe("insert, update, delete with count: 'exact'", () => {
     expect(res).toMatchSnapshot()
   })
 })
+
+test('insert includes columns param', async () => {
+  const client = postgrest.from('users').insert([{ foo: 1 }, { bar: 2 }])
+  expect((client as any).url.searchParams.get('columns')).toMatchInlineSnapshot(`"foo,bar"`)
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Bulk insert doesn't have [columns](https://postgrest.org/en/stable/api.html#specifying-columns) param.

## What is the new behavior?

Adds the param. Fixes #175.