### PR TITLE
fix(rpc): allow filters on rpc

### DIFF
--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -1,6 +1,6 @@
 import PostgrestQueryBuilder from './lib/PostgrestQueryBuilder'
 import PostgrestRpcBuilder from './lib/PostgrestRpcBuilder'
-import PostgrestTransformBuilder from './lib/PostgrestTransformBuilder'
+import PostgrestFilterBuilder from './lib/PostgrestFilterBuilder'
 
 export default class PostgrestClient {
   url: string
@@ -58,7 +58,7 @@ export default class PostgrestClient {
     }: {
       count?: null | 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestTransformBuilder<T> {
+  ): PostgrestFilterBuilder<T> {
     const url = `${this.url}/rpc/${fn}`
     return new PostgrestRpcBuilder<T>(url, {
       headers: this.headers,

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -1,5 +1,5 @@
 import { PostgrestBuilder } from './types'
-import PostgrestTransformBuilder from './PostgrestTransformBuilder'
+import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 
 export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
   constructor(
@@ -22,7 +22,7 @@ export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
     }: {
       count?: null | 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestTransformBuilder<T> {
+  ): PostgrestFilterBuilder<T> {
     this.method = 'POST'
     this.body = params
 
@@ -31,6 +31,6 @@ export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
       else this.headers['Prefer'] = `count=${count}`
     }
 
-    return new PostgrestTransformBuilder(this)
+    return new PostgrestFilterBuilder(this)
   }
 }

--- a/test/filters.ts
+++ b/test/filters.ts
@@ -743,3 +743,19 @@ test('match', async () => {
     }
   `)
 })
+
+test('filter on stored procedure', async () => {
+  const res = await postgrest
+    .rpc('get_username_and_status', { name_param: 'supabot' })
+    .neq('status', 'ONLINE')
+  expect(res).toMatchInlineSnapshot(`
+    Object {
+      "body": Array [],
+      "count": null,
+      "data": Array [],
+      "error": null,
+      "status": 200,
+      "statusText": "OK",
+    }
+  `)
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Stored procedures (`rpc()`) return `PostgrestTransformBuilder` and thus doesn't support filters (`eq()`, etc.).

## What is the new behavior?

Return `PostgrestFilterBuilder` to support filters.