### PR TITLE
fix: insert w/ empty body can't have columns param

### DIFF
--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -109,8 +109,10 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
 
     if (Array.isArray(values)) {
       const columns = values.reduce((acc, x) => acc.concat(Object.keys(x)), [] as string[])
-      const uniqueColumns = [...new Set(columns)]
-      this.url.searchParams.set('columns', uniqueColumns.join(','))
+      if (columns.length > 0) {
+        const uniqueColumns = [...new Set(columns)]
+        this.url.searchParams.set('columns', uniqueColumns.join(','))
+      }
     }
 
     return new PostgrestFilterBuilder(this)

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -239,3 +239,8 @@ test('insert includes columns param', async () => {
   const client = postgrest.from('users').insert([{ foo: 1 }, { bar: 2 }])
   expect((client as any).url.searchParams.get('columns')).toMatchInlineSnapshot(`"foo,bar"`)
 })
+
+test('insert w/ empty body has no columns param', async () => {
+  const client = postgrest.from('users').insert([{}, {}])
+  expect((client as any).url.searchParams.has('columns')).toBeFalsy()
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`insert()` with empty body, i.e. no columns in any of the values (e.g. `[{}, {}]`) gives a `columns` query parameter with no value, leading to `failed to parse columns parameter ()` error.

## What is the new behavior?

Omit `columns` param when no column is specified.