### PR TITLE
CSV Response

### DIFF
--- a/src/lib/PostgrestTransformBuilder.ts
+++ b/src/lib/PostgrestTransformBuilder.ts
@@ -93,4 +93,12 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
     this.headers['Accept'] = 'application/vnd.pgrst.object+json'
     return this as PromiseLike<PostgrestSingleResponse<T>>
   }
+
+  /**
+   * Set the response type to CSV.
+   */
+   csv(): this {
+    this.headers['Accept'] = 'text/csv'
+    return this
+  }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -91,7 +91,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
           const isReturnMinimal = this.headers['Prefer']?.split(',').includes('return=minimal')
           if (this.method !== 'HEAD' && !isReturnMinimal) {
             const text = await res.text()
-            if (text && text !== '') data = JSON.parse(text)
+            if (text && text !== '' &&  this.headers['Accept'] !== 'text/csv') data = JSON.parse(text)
           }
 
           const countHeader = this.headers['Prefer']?.match(/count=(exact|planned|estimated)/)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Response is always a JSON.

## What is the new behavior?

Ability to set response type to CSV. Usage:
```
postgrest
.from('table')
.csv()
.select()
```

## Additional context

CSV responses can be super convenient for some use cases (https://github.com/supabase/postgrest-js/issues/186) but also save plenty of resources used (wasted) by large response sizes (https://github.com/supabase/supabase-js/issues/189)
