### PR TITLE
Implement unwrap() to throw query errors instead of returning them

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,20 +53,20 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
   protected headers!: { [key: string]: string }
   protected schema?: string
   protected body?: Partial<T> | Partial<T>[]
-  protected unwrapError?: boolean
+  protected shouldThrowOnError?: boolean
 
   constructor(builder: PostgrestBuilder<T>) {
     Object.assign(this, builder)
   }
 
   /**
-   * If there's an error with the query, unwrap will reject the promise by
+   * If there's an error with the query, throwOnError will reject the promise by
    * throwing the error instead of returning it as part of a successful response.
    *
    * {@link https://github.com/supabase/supabase-js/issues/92}
    */
-  unwrap(): PostgrestBuilder<T> {
-    this.unwrapError = true
+  throwOnError(): PostgrestBuilder<T> {
+    this.shouldThrowOnError = true
     return this
   }
 
@@ -115,7 +115,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
         } else {
           error = await res.json()
 
-          if (error && this.unwrapError) {
+          if (error && this.shouldThrowOnError) {
             throw error
           }
         }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,9 +53,21 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
   protected headers!: { [key: string]: string }
   protected schema?: string
   protected body?: Partial<T> | Partial<T>[]
+  protected unwrapError?: boolean
 
   constructor(builder: PostgrestBuilder<T>) {
     Object.assign(this, builder)
+  }
+
+  /**
+   * If there's an error with the query, unwrap will reject the promise by
+   * throwing the error instead of returning it as part of a successful response.
+   *
+   * {@link https://github.com/supabase/supabase-js/issues/92}
+   */
+  unwrap(): PostgrestBuilder<T> {
+    this.unwrapError = true
+    return this
   }
 
   then<TResult1 = PostgrestResponse<T>, TResult2 = never>(
@@ -91,7 +103,8 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
           const isReturnMinimal = this.headers['Prefer']?.split(',').includes('return=minimal')
           if (this.method !== 'HEAD' && !isReturnMinimal) {
             const text = await res.text()
-            if (text && text !== '' &&  this.headers['Accept'] !== 'text/csv') data = JSON.parse(text)
+            if (text && text !== '' && this.headers['Accept'] !== 'text/csv')
+              data = JSON.parse(text)
           }
 
           const countHeader = this.headers['Prefer']?.match(/count=(exact|planned|estimated)/)
@@ -101,6 +114,10 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
           }
         } else {
           error = await res.json()
+
+          if (error && this.unwrapError) {
+            throw error
+          }
         }
 
         const postgrestResponse: PostgrestResponse<T> = {
@@ -111,6 +128,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
           statusText: res.statusText,
           body: data,
         }
+
         return postgrestResponse
       })
       .then(onfulfilled, onrejected)

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -626,6 +626,8 @@ Object {
 }
 `;
 
+exports[`connection error when unwrapping too 1`] = `[FetchError: request to http://this.url.does.not.exist/user?select=* failed, reason: getaddrinfo ENOTFOUND this.url.does.not.exist]`;
+
 exports[`don't mutate PostgrestClient.headers 1`] = `null`;
 
 exports[`embedded filters embedded eq 1`] = `
@@ -2249,5 +2251,14 @@ Object {
   "error": null,
   "status": 200,
   "statusText": "OK",
+}
+`;
+
+exports[`unwrap throws errors instead of returning them 1`] = `
+Object {
+  "code": "42P01",
+  "details": null,
+  "hint": null,
+  "message": "relation \\"public.missing_table\\" does not exist",
 }
 `;

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -626,7 +626,7 @@ Object {
 }
 `;
 
-exports[`connection error when unwrapping too 1`] = `[FetchError: request to http://this.url.does.not.exist/user?select=* failed, reason: getaddrinfo ENOTFOUND this.url.does.not.exist]`;
+exports[`connection errors should work the same with throwOnError 1`] = `[FetchError: request to http://this.url.does.not.exist/user?select=* failed, reason: getaddrinfo ENOTFOUND this.url.does.not.exist]`;
 
 exports[`don't mutate PostgrestClient.headers 1`] = `null`;
 
@@ -2254,7 +2254,7 @@ Object {
 }
 `;
 
-exports[`unwrap throws errors instead of returning them 1`] = `
+exports[`throwOnError throws errors instead of returning them 1`] = `
 Object {
   "code": "42P01",
   "details": null,

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -95,11 +95,11 @@ test('missing table', async () => {
   expect(res).toMatchSnapshot()
 })
 
-test('unwrap throws errors instead of returning them', async () => {
+test('throwOnError throws errors instead of returning them', async () => {
   let isErrorCaught = false
 
   try {
-    await postgrest.from('missing_table').select().unwrap()
+    await postgrest.from('missing_table').select().throwOnError()
   } catch (error) {
     expect(error).toMatchSnapshot()
     isErrorCaught = true
@@ -120,14 +120,14 @@ test('connection error', async () => {
   expect(isErrorCaught).toBe(true)
 })
 
-test('connection error when unwrapping too', async () => {
+test('connection errors should work the same with throwOnError', async () => {
   const postgrest = new PostgrestClient('http://this.url.does.not.exist')
   let isErrorCaught = false
   await postgrest
     .from('user')
     .select()
-    .unwrap()
-    .then(undefined, error => {
+    .throwOnError()
+    .then(undefined, (error) => {
       expect(error).toMatchSnapshot()
       isErrorCaught = true
     })

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -95,6 +95,19 @@ test('missing table', async () => {
   expect(res).toMatchSnapshot()
 })
 
+test('unwrap throws errors instead of returning them', async () => {
+  let isErrorCaught = false
+
+  try {
+    await postgrest.from('missing_table').select().unwrap()
+  } catch (error) {
+    expect(error).toMatchSnapshot()
+    isErrorCaught = true
+  }
+
+  expect(isErrorCaught).toBe(true)
+})
+
 test('connection error', async () => {
   const postgrest = new PostgrestClient('http://this.url.does.not.exist')
   let isErrorCaught = false
@@ -102,6 +115,20 @@ test('connection error', async () => {
     .from('user')
     .select()
     .then(undefined, () => {
+      isErrorCaught = true
+    })
+  expect(isErrorCaught).toBe(true)
+})
+
+test('connection error when unwrapping too', async () => {
+  const postgrest = new PostgrestClient('http://this.url.does.not.exist')
+  let isErrorCaught = false
+  await postgrest
+    .from('user')
+    .select()
+    .unwrap()
+    .then(undefined, error => {
+      expect(error).toMatchSnapshot()
       isErrorCaught = true
     })
   expect(isErrorCaught).toBe(true)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This adds an `unwrap()` function on the PostgrestBuilder class, which means errors will be thrown instead of returned.

Basic tests were added to test/basic.ts and the unwrap function is documented to some degree at least, though this can probably be improved. This should be a non-breaking change as it just adds functionality, it doesn't change any existing features.

## What is the current behavior?

Supabase queries return errors as part of a successful response, i.e. the promise is resolved. The exception (no pun intended) to this is if there's something wrong with the fetch call itself, such as a network error – these will lead to the promise rejecting and can be handled in a try/catch block. This leads to somewhat awkward code:

```javascript
try {
  const { data, error } = await supabase.from('my_table').select()

  if (error) {
    // This means there was an error with the query, we have to rethrow in order to handle it all below
  }
} catch (e) {
  // This means there was an error with the actual fetching, e.g. network issues
}
```

## What is the new behavior?

By adding `unwrap()` to the query, we instruct the client to throw errors instead of returning them, meaning we can simplify the above:

```javascript
try {
  const { data } = await supabase.from('my_table').select().unwrap()
} catch (e) {
  // This catches all errors, be they network or query related
}
```

## Additional context

The rationale and motivation for this change is well described in supabase/supabase-js#92 I think, and also there's some rambling from me around this in supabase/supabase#604.

This implementation doesn't actually unwrap the result as described in supabase/supabase-js#92, i.e. returning only the actual data. This is done deliberately for two reasons:

1. Making sure the caller can still extract `count`, `status` and `statusText` while still benefitting from errors being thrown instead of returned
2. Ease the transition from the non-throwing pattern where destructuring is norm anyway, so less code has to be rewritten to take advantage of unwrap

It may be worth considering normalizing the network errors in a new major version of the client, so that network errors are also by default returned as part of a resolved promise. That way, you'd have consistent error handling no matter what the issue was – either you use the `{ data, error } = ...` pattern regardless of error type, or you tack on `unwrap()` and all errors get thrown. I think that's out of scope for this PR though.