### PR TITLE
feat: Implement and export full typings

### DIFF
--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -1,10 +1,10 @@
 import PostgrestQueryBuilder from './lib/PostgrestQueryBuilder'
 import PostgrestRpcBuilder from './lib/PostgrestRpcBuilder'
-import PostgrestFilterBuilder from './lib/PostgrestFilterBuilder'
+import { Client, ClientConfig, FilterBuilder, QueryBuilder, RpcOptions } from './lib/types'
 
-export default class PostgrestClient {
+export default class PostgrestClient implements Client {
   url: string
-  headers: { [key: string]: string }
+  headers: Record<string, string>
   schema?: string
 
   /**
@@ -14,10 +14,7 @@ export default class PostgrestClient {
    * @param headers  Custom headers.
    * @param schema  Postgres schema to switch to.
    */
-  constructor(
-    url: string,
-    { headers = {}, schema }: { headers?: { [key: string]: string }; schema?: string } = {}
-  ) {
+  constructor(url: string, { headers = {}, schema }: ClientConfig = {}) {
     this.url = url
     this.headers = headers
     this.schema = schema
@@ -28,7 +25,7 @@ export default class PostgrestClient {
    *
    * @param token  The JWT token to use.
    */
-  auth(token: string): this {
+  auth(token: string): Client {
     this.headers['Authorization'] = `Bearer ${token}`
     return this
   }
@@ -38,7 +35,7 @@ export default class PostgrestClient {
    *
    * @param table  The table name to operate on.
    */
-  from<T = any>(table: string): PostgrestQueryBuilder<T> {
+  from<T = any>(table: string): QueryBuilder<T> {
     const url = `${this.url}/${table}`
     return new PostgrestQueryBuilder<T>(url, { headers: this.headers, schema: this.schema })
   }
@@ -53,12 +50,8 @@ export default class PostgrestClient {
   rpc<T = any>(
     fn: string,
     params?: object,
-    {
-      count = null,
-    }: {
-      count?: null | 'exact' | 'planned' | 'estimated'
-    } = {}
-  ): PostgrestFilterBuilder<T> {
+    { count }: RpcOptions = { count: null }
+  ): FilterBuilder<T> {
     const url = `${this.url}/rpc/${fn}`
     return new PostgrestRpcBuilder<T>(url, {
       headers: this.headers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@ import PostgrestQueryBuilder from './lib/PostgrestQueryBuilder'
 import { PostgrestBuilder } from './lib/types'
 
 export { PostgrestClient, PostgrestFilterBuilder, PostgrestQueryBuilder, PostgrestBuilder }
+
+export * from './lib/types'

--- a/src/lib/PostgrestFilterBuilder.ts
+++ b/src/lib/PostgrestFilterBuilder.ts
@@ -1,34 +1,9 @@
 import PostgrestTransformBuilder from './PostgrestTransformBuilder'
+import { FilterBuilder, FilterOperator } from './types'
 
-/**
- * Filters
- */
-
-type FilterOperator =
-  | 'eq'
-  | 'neq'
-  | 'gt'
-  | 'gte'
-  | 'lt'
-  | 'lte'
-  | 'like'
-  | 'ilike'
-  | 'is'
-  | 'in'
-  | 'cs'
-  | 'cd'
-  | 'sl'
-  | 'sr'
-  | 'nxl'
-  | 'nxr'
-  | 'adj'
-  | 'ov'
-  | 'fts'
-  | 'plfts'
-  | 'phfts'
-  | 'wfts'
-
-export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
+export default class PostgrestFilterBuilder<T>
+  extends PostgrestTransformBuilder<T>
+  implements FilterBuilder<T> {
   /**
    * Finds all rows which doesn't satisfy the filter.
    *
@@ -36,7 +11,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param operator  The operator to filter with.
    * @param value  The value to filter with.
    */
-  not(column: keyof T, operator: FilterOperator, value: any): this {
+  not(column: keyof T, operator: FilterOperator, value: any): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `not.${operator}.${value}`)
     return this
   }
@@ -47,7 +22,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param filters  The filters to use, separated by commas.
    * @param foreignTable  The foreign table to use (if `column` is a foreign column).
    */
-  or(filters: string, { foreignTable }: { foreignTable?: string } = {}): this {
+  or(filters: string, { foreignTable }: { foreignTable?: string } = {}): FilterBuilder<T> {
     const key = typeof foreignTable === 'undefined' ? 'or' : `${foreignTable}.or`
     this.url.searchParams.append(key, `(${filters})`)
     return this
@@ -60,7 +35,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  eq(column: keyof T, value: T[keyof T]): this {
+  eq(column: keyof T, value: T[keyof T]): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `eq.${value}`)
     return this
   }
@@ -72,7 +47,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  neq(column: keyof T, value: T[keyof T]): this {
+  neq(column: keyof T, value: T[keyof T]): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `neq.${value}`)
     return this
   }
@@ -84,7 +59,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  gt(column: keyof T, value: T[keyof T]): this {
+  gt(column: keyof T, value: T[keyof T]): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `gt.${value}`)
     return this
   }
@@ -96,7 +71,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  gte(column: keyof T, value: T[keyof T]): this {
+  gte(column: keyof T, value: T[keyof T]): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `gte.${value}`)
     return this
   }
@@ -108,7 +83,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  lt(column: keyof T, value: T[keyof T]): this {
+  lt(column: keyof T, value: T[keyof T]): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `lt.${value}`)
     return this
   }
@@ -120,7 +95,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  lte(column: keyof T, value: T[keyof T]): this {
+  lte(column: keyof T, value: T[keyof T]): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `lte.${value}`)
     return this
   }
@@ -132,7 +107,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param pattern  The pattern to filter with.
    */
-  like(column: keyof T, pattern: string): this {
+  like(column: keyof T, pattern: string): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `like.${pattern}`)
     return this
   }
@@ -144,7 +119,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param pattern  The pattern to filter with.
    */
-  ilike(column: keyof T, pattern: string): this {
+  ilike(column: keyof T, pattern: string): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `ilike.${pattern}`)
     return this
   }
@@ -156,7 +131,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  is(column: keyof T, value: boolean | null): this {
+  is(column: keyof T, value: boolean | null): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `is.${value}`)
     return this
   }
@@ -168,7 +143,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param values  The values to filter with.
    */
-  in(column: keyof T, values: T[keyof T][]): this {
+  in(column: keyof T, values: T[keyof T][]): FilterBuilder<T> {
     const cleanedValues = values
       .map((s) => {
         // handle postgrest reserved characters
@@ -188,7 +163,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  contains(column: keyof T, value: string | T[keyof T][] | object): this {
+  contains(column: keyof T, value: string | T[keyof T][] | object): FilterBuilder<T> {
     if (typeof value === 'string') {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
       // keep it simple and accept a string
@@ -213,7 +188,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  containedBy(column: keyof T, value: string | T[keyof T][] | object): this {
+  containedBy(column: keyof T, value: string | T[keyof T][] | object): FilterBuilder<T> {
     if (typeof value === 'string') {
       // range
       this.url.searchParams.append(`${column}`, `cd.${value}`)
@@ -237,7 +212,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeLt(column: keyof T, range: string): this {
+  rangeLt(column: keyof T, range: string): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `sl.${range}`)
     return this
   }
@@ -252,7 +227,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeGt(column: keyof T, range: string): this {
+  rangeGt(column: keyof T, range: string): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `sr.${range}`)
     return this
   }
@@ -267,7 +242,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeGte(column: keyof T, range: string): this {
+  rangeGte(column: keyof T, range: string): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `nxl.${range}`)
     return this
   }
@@ -282,7 +257,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeLte(column: keyof T, range: string): this {
+  rangeLte(column: keyof T, range: string): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `nxr.${range}`)
     return this
   }
@@ -297,7 +272,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeAdjacent(column: keyof T, range: string): this {
+  rangeAdjacent(column: keyof T, range: string): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `adj.${range}`)
     return this
   }
@@ -312,7 +287,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  overlaps(column: keyof T, value: string | T[keyof T][]): this {
+  overlaps(column: keyof T, value: string | T[keyof T][]): FilterBuilder<T> {
     if (typeof value === 'string') {
       // range
       this.url.searchParams.append(`${column}`, `ov.${value}`)
@@ -342,7 +317,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
       config,
       type = null,
     }: { config?: string; type?: 'plain' | 'phrase' | 'websearch' | null } = {}
-  ): this {
+  ): FilterBuilder<T> {
     let typePart = ''
     if (type === 'plain') {
       typePart = 'pl'
@@ -366,7 +341,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    *
    * @deprecated Use `textSearch()` instead.
    */
-  fts(column: keyof T, query: string, { config }: { config?: string } = {}): this {
+  fts(column: keyof T, query: string, { config }: { config?: string } = {}): FilterBuilder<T> {
     const configPart = typeof config === 'undefined' ? '' : `(${config})`
     this.url.searchParams.append(`${column}`, `fts${configPart}.${query}`)
     return this
@@ -382,7 +357,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    *
    * @deprecated Use `textSearch()` with `type: 'plain'` instead.
    */
-  plfts(column: keyof T, query: string, { config }: { config?: string } = {}): this {
+  plfts(column: keyof T, query: string, { config }: { config?: string } = {}): FilterBuilder<T> {
     const configPart = typeof config === 'undefined' ? '' : `(${config})`
     this.url.searchParams.append(`${column}`, `plfts${configPart}.${query}`)
     return this
@@ -398,7 +373,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    *
    * @deprecated Use `textSearch()` with `type: 'phrase'` instead.
    */
-  phfts(column: keyof T, query: string, { config }: { config?: string } = {}): this {
+  phfts(column: keyof T, query: string, { config }: { config?: string } = {}): FilterBuilder<T> {
     const configPart = typeof config === 'undefined' ? '' : `(${config})`
     this.url.searchParams.append(`${column}`, `phfts${configPart}.${query}`)
     return this
@@ -414,7 +389,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    *
    * @deprecated Use `textSearch()` with `type: 'websearch'` instead.
    */
-  wfts(column: keyof T, query: string, { config }: { config?: string } = {}): this {
+  wfts(column: keyof T, query: string, { config }: { config?: string } = {}): FilterBuilder<T> {
     const configPart = typeof config === 'undefined' ? '' : `(${config})`
     this.url.searchParams.append(`${column}`, `wfts${configPart}.${query}`)
     return this
@@ -427,7 +402,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param operator  The operator to filter with.
    * @param value  The value to filter with.
    */
-  filter(column: keyof T, operator: FilterOperator, value: any): this {
+  filter(column: keyof T, operator: FilterOperator, value: any): FilterBuilder<T> {
     this.url.searchParams.append(`${column}`, `${operator}.${value}`)
     return this
   }
@@ -438,7 +413,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param query  The object to filter with, with column names as keys mapped
    *               to their filter values.
    */
-  match(query: { [key: string]: string }) {
+  match(query: { [key: string]: string }): FilterBuilder<T> {
     Object.keys(query).forEach((key) => {
       this.url.searchParams.append(`${key}`, `eq.${query[key]}`)
     })

--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -1,11 +1,20 @@
-import { PostgrestBuilder } from './types'
+import {
+  DeleteOptions,
+  FilterBuilder,
+  InsertOptions,
+  PostgrestBuilder,
+  QueryBuilder,
+  QueryBuilderConfig,
+  SelectOptions,
+  UpdateOptions,
+  UpsertOptions,
+} from './types'
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 
-export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
-  constructor(
-    url: string,
-    { headers = {}, schema }: { headers?: { [key: string]: string }; schema?: string } = {}
-  ) {
+export default class PostgrestQueryBuilder<T>
+  extends PostgrestBuilder<T>
+  implements QueryBuilder<T> {
+  constructor(url: string, { headers = {}, schema }: QueryBuilderConfig = {}) {
     super({} as PostgrestBuilder<T>)
     this.url = new URL(url)
     this.headers = { ...headers }
@@ -19,16 +28,7 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
    * @param head  When set to true, select will void data.
    * @param count  Count algorithm to use to count rows in a table.
    */
-  select(
-    columns = '*',
-    {
-      head = false,
-      count = null,
-    }: {
-      head?: boolean
-      count?: null | 'exact' | 'planned' | 'estimated'
-    } = {}
-  ): PostgrestFilterBuilder<T> {
+  select(columns = '*', { head = false, count = null }: SelectOptions = {}): FilterBuilder<T> {
     this.method = 'GET'
     // Remove whitespaces except when quoted
     let quoted = false
@@ -61,39 +61,15 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
    * @param returning  By default the new record is returned. Set this to 'minimal' if you don't need this value.
    * @param count  Count algorithm to use to count rows in a table.
    */
-  insert(
-    values: Partial<T> | Partial<T>[],
-    options?: {
-      returning?: 'minimal' | 'representation'
-      count?: null | 'exact' | 'planned' | 'estimated'
-    }
-  ): PostgrestFilterBuilder<T>
+  insert(values: Partial<T> | Partial<T>[], options?: InsertOptions): FilterBuilder<T>
   /**
    * @deprecated Use `upsert()` instead.
    */
+  insert(values: Partial<T> | Partial<T>[], options?: InsertOptions): FilterBuilder<T>
   insert(
     values: Partial<T> | Partial<T>[],
-    options?: {
-      upsert?: boolean
-      onConflict?: string
-      returning?: 'minimal' | 'representation'
-      count?: null | 'exact' | 'planned' | 'estimated'
-    }
-  ): PostgrestFilterBuilder<T>
-  insert(
-    values: Partial<T> | Partial<T>[],
-    {
-      upsert = false,
-      onConflict,
-      returning = 'representation',
-      count = null,
-    }: {
-      upsert?: boolean
-      onConflict?: string
-      returning?: 'minimal' | 'representation'
-      count?: null | 'exact' | 'planned' | 'estimated'
-    } = {}
-  ): PostgrestFilterBuilder<T> {
+    { upsert = false, onConflict, returning = 'representation', count = null }: InsertOptions = {}
+  ): FilterBuilder<T> {
     this.method = 'POST'
 
     const prefersHeaders = [`return=${returning}`]
@@ -128,16 +104,8 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
    */
   upsert(
     values: Partial<T> | Partial<T>[],
-    {
-      onConflict,
-      returning = 'representation',
-      count = null,
-    }: {
-      onConflict?: string
-      returning?: 'minimal' | 'representation'
-      count?: null | 'exact' | 'planned' | 'estimated'
-    } = {}
-  ): PostgrestFilterBuilder<T> {
+    { onConflict, returning = 'representation', count = null }: UpsertOptions = {}
+  ): FilterBuilder<T> {
     this.method = 'POST'
 
     const prefersHeaders = ['resolution=merge-duplicates', `return=${returning}`]
@@ -162,14 +130,8 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
    */
   update(
     values: Partial<T>,
-    {
-      returning = 'representation',
-      count = null,
-    }: {
-      returning?: 'minimal' | 'representation'
-      count?: null | 'exact' | 'planned' | 'estimated'
-    } = {}
-  ): PostgrestFilterBuilder<T> {
+    { returning = 'representation', count = null }: UpdateOptions = {}
+  ): FilterBuilder<T> {
     this.method = 'PATCH'
     const prefersHeaders = [`return=${returning}`]
     this.body = values
@@ -186,13 +148,7 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
    * @param returning  If `true`, return the deleted row(s) in the response.
    * @param count  Count algorithm to use to count rows in a table.
    */
-  delete({
-    returning = 'representation',
-    count = null,
-  }: {
-    returning?: 'minimal' | 'representation'
-    count?: null | 'exact' | 'planned' | 'estimated'
-  } = {}): PostgrestFilterBuilder<T> {
+  delete({ returning = 'representation', count = null }: DeleteOptions = {}): FilterBuilder<T> {
     this.method = 'DELETE'
     const prefersHeaders = [`return=${returning}`]
     if (count) {

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -2,10 +2,7 @@ import { FilterBuilder, PostgrestBuilder, RpcBuilder, RpcBuilderConfig, RpcOptio
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 
 export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> implements RpcBuilder<T> {
-  constructor(
-    url: string,
-    { headers = {}, schema }: RpcBuilderConfig = {}
-  ) {
+  constructor(url: string, { headers = {}, schema }: RpcBuilderConfig = {}) {
     super({} as PostgrestBuilder<T>)
     this.url = new URL(url)
     this.headers = { ...headers }

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -1,7 +1,7 @@
-import { PostgrestBuilder } from './types'
+import { PostgrestBuilder, RpcBuilder, RpcOptions } from './types'
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 
-export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
+export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> implements RpcBuilder<T> {
   constructor(
     url: string,
     { headers = {}, schema }: { headers?: { [key: string]: string }; schema?: string } = {}
@@ -15,14 +15,7 @@ export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
   /**
    * Perform a stored procedure call.
    */
-  rpc(
-    params?: object,
-    {
-      count = null,
-    }: {
-      count?: null | 'exact' | 'planned' | 'estimated'
-    } = {}
-  ): PostgrestFilterBuilder<T> {
+  rpc(params?: object, { count = null }: RpcOptions = {}): PostgrestFilterBuilder<T> {
     this.method = 'POST'
     this.body = params
 

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -1,10 +1,10 @@
-import { PostgrestBuilder, RpcBuilder, RpcOptions } from './types'
+import { FilterBuilder, PostgrestBuilder, RpcBuilder, RpcBuilderConfig, RpcOptions } from './types'
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 
 export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> implements RpcBuilder<T> {
   constructor(
     url: string,
-    { headers = {}, schema }: { headers?: { [key: string]: string }; schema?: string } = {}
+    { headers = {}, schema }: RpcBuilderConfig = {}
   ) {
     super({} as PostgrestBuilder<T>)
     this.url = new URL(url)
@@ -15,7 +15,7 @@ export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> implemen
   /**
    * Perform a stored procedure call.
    */
-  rpc(params?: object, { count = null }: RpcOptions = {}): PostgrestFilterBuilder<T> {
+  rpc(params?: object, { count = null }: RpcOptions = {}): FilterBuilder<T> {
     this.method = 'POST'
     this.body = params
 

--- a/src/lib/PostgrestTransformBuilder.ts
+++ b/src/lib/PostgrestTransformBuilder.ts
@@ -1,16 +1,23 @@
-import { PostgrestBuilder, PostgrestMaybeSingleResponse, PostgrestSingleResponse } from './types'
+import {
+  PostgrestBuilder,
+  PostgrestMaybeSingleResponse,
+  PostgrestSingleResponse,
+  TransformBuilder,
+} from './types'
 
 /**
  * Post-filters (transforms)
  */
 
-export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
+export default class PostgrestTransformBuilder<T>
+  extends PostgrestBuilder<T>
+  implements TransformBuilder<T> {
   /**
    * Performs vertical filtering with SELECT.
    *
    * @param columns  The columns to retrieve, separated by commas.
    */
-  select(columns = '*'): this {
+  select(columns = '*'): TransformBuilder<T> {
     // Remove whitespaces except when quoted
     let quoted = false
     const cleanedColumns = columns
@@ -44,7 +51,7 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
       nullsFirst = false,
       foreignTable,
     }: { ascending?: boolean; nullsFirst?: boolean; foreignTable?: string } = {}
-  ): this {
+  ): TransformBuilder<T> {
     const key = typeof foreignTable === 'undefined' ? 'order' : `${foreignTable}.order`
     const existingOrder = this.url.searchParams.get(key)
 
@@ -63,7 +70,7 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
    * @param count  The maximum no. of rows to limit to.
    * @param foreignTable  The foreign table to use (for foreign columns).
    */
-  limit(count: number, { foreignTable }: { foreignTable?: string } = {}): this {
+  limit(count: number, { foreignTable }: { foreignTable?: string } = {}): TransformBuilder<T> {
     const key = typeof foreignTable === 'undefined' ? 'limit' : `${foreignTable}.limit`
     this.url.searchParams.set(key, `${count}`)
     return this
@@ -76,7 +83,11 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
    * @param to  The last index to which to limit the result, inclusive.
    * @param foreignTable  The foreign table to use (for foreign columns).
    */
-  range(from: number, to: number, { foreignTable }: { foreignTable?: string } = {}): this {
+  range(
+    from: number,
+    to: number,
+    { foreignTable }: { foreignTable?: string } = {}
+  ): TransformBuilder<T> {
     const keyOffset = typeof foreignTable === 'undefined' ? 'offset' : `${foreignTable}.offset`
     const keyLimit = typeof foreignTable === 'undefined' ? 'limit' : `${foreignTable}.limit`
     this.url.searchParams.set(keyOffset, `${from}`)
@@ -123,7 +134,7 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
   /**
    * Set the response type to CSV.
    */
-  csv(): this {
+  csv(): TransformBuilder<T> {
     this.headers['Accept'] = 'text/csv'
     return this
   }

--- a/src/lib/PostgrestTransformBuilder.ts
+++ b/src/lib/PostgrestTransformBuilder.ts
@@ -3,8 +3,9 @@ import {
   OrderOptions,
   PostgrestBuilder,
   PostgrestMaybeSingleResponse,
-  PostgrestSingleResponse, RangeOptions,
-  TransformBuilder
+  PostgrestSingleResponse,
+  RangeOptions,
+  TransformBuilder,
 } from './types'
 
 /**
@@ -48,11 +49,7 @@ export default class PostgrestTransformBuilder<T>
    */
   order(
     column: keyof T,
-    {
-      ascending = true,
-      nullsFirst = false,
-      foreignTable,
-    }: OrderOptions = {}
+    { ascending = true, nullsFirst = false, foreignTable }: OrderOptions = {}
   ): TransformBuilder<T> {
     const key = typeof foreignTable === 'undefined' ? 'order' : `${foreignTable}.order`
     const existingOrder = this.url.searchParams.get(key)
@@ -85,11 +82,7 @@ export default class PostgrestTransformBuilder<T>
    * @param to  The last index to which to limit the result, inclusive.
    * @param foreignTable  The foreign table to use (for foreign columns).
    */
-  range(
-    from: number,
-    to: number,
-    { foreignTable }: RangeOptions = {}
-  ): TransformBuilder<T> {
+  range(from: number, to: number, { foreignTable }: RangeOptions = {}): TransformBuilder<T> {
     const keyOffset = typeof foreignTable === 'undefined' ? 'offset' : `${foreignTable}.offset`
     const keyLimit = typeof foreignTable === 'undefined' ? 'limit' : `${foreignTable}.limit`
     this.url.searchParams.set(keyOffset, `${from}`)

--- a/src/lib/PostgrestTransformBuilder.ts
+++ b/src/lib/PostgrestTransformBuilder.ts
@@ -1,8 +1,10 @@
 import {
+  LimitOptions,
+  OrderOptions,
   PostgrestBuilder,
   PostgrestMaybeSingleResponse,
-  PostgrestSingleResponse,
-  TransformBuilder,
+  PostgrestSingleResponse, RangeOptions,
+  TransformBuilder
 } from './types'
 
 /**
@@ -50,7 +52,7 @@ export default class PostgrestTransformBuilder<T>
       ascending = true,
       nullsFirst = false,
       foreignTable,
-    }: { ascending?: boolean; nullsFirst?: boolean; foreignTable?: string } = {}
+    }: OrderOptions = {}
   ): TransformBuilder<T> {
     const key = typeof foreignTable === 'undefined' ? 'order' : `${foreignTable}.order`
     const existingOrder = this.url.searchParams.get(key)
@@ -70,7 +72,7 @@ export default class PostgrestTransformBuilder<T>
    * @param count  The maximum no. of rows to limit to.
    * @param foreignTable  The foreign table to use (for foreign columns).
    */
-  limit(count: number, { foreignTable }: { foreignTable?: string } = {}): TransformBuilder<T> {
+  limit(count: number, { foreignTable }: LimitOptions = {}): TransformBuilder<T> {
     const key = typeof foreignTable === 'undefined' ? 'limit' : `${foreignTable}.limit`
     this.url.searchParams.set(key, `${count}`)
     return this
@@ -86,7 +88,7 @@ export default class PostgrestTransformBuilder<T>
   range(
     from: number,
     to: number,
-    { foreignTable }: { foreignTable?: string } = {}
+    { foreignTable }: RangeOptions = {}
   ): TransformBuilder<T> {
     const keyOffset = typeof foreignTable === 'undefined' ? 'offset' : `${foreignTable}.offset`
     const keyLimit = typeof foreignTable === 'undefined' ? 'limit' : `${foreignTable}.limit`

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,11 +1,38 @@
 import fetch from 'cross-fetch'
 
 /**
+ * Filter operator tokens
+ */
+export type FilterOperator =
+  | 'eq'
+  | 'neq'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'like'
+  | 'ilike'
+  | 'is'
+  | 'in'
+  | 'cs'
+  | 'cd'
+  | 'sl'
+  | 'sr'
+  | 'nxl'
+  | 'nxr'
+  | 'adj'
+  | 'ov'
+  | 'fts'
+  | 'plfts'
+  | 'phfts'
+  | 'wfts'
+
+/**
  * Error format
  *
  * {@link https://postgrest.org/en/stable/api.html?highlight=options#errors-and-http-status-codes}
  */
-type PostgrestError = {
+export interface PostgrestError {
   message: string
   details: string
   hint: string
@@ -17,38 +44,215 @@ type PostgrestError = {
  *
  * {@link https://github.com/supabase/supabase-js/issues/32}
  */
-interface PostgrestResponseBase {
+export interface PostgrestResponseBase {
   status: number
   statusText: string
 }
 
-interface PostgrestResponseSuccess<T> extends PostgrestResponseBase {
+export interface PostgrestResponseSuccess<T> extends PostgrestResponseBase {
   error: null
   data: T[]
   body: T[]
   count: number | null
 }
-interface PostgrestResponseFailure extends PostgrestResponseBase {
+
+export interface PostgrestResponseFailure extends PostgrestResponseBase {
   error: PostgrestError
   data: null
   // For backward compatibility: body === data
   body: null
   count: null
 }
+
 export type PostgrestResponse<T> = PostgrestResponseSuccess<T> | PostgrestResponseFailure
 
-interface PostgrestSingleResponseSuccess<T> extends PostgrestResponseBase {
+export interface PostgrestSingleResponseSuccess<T> extends PostgrestResponseBase {
   error: null
   data: T
   // For backward compatibility: body === data
   body: T
 }
+
 export type PostgrestSingleResponse<T> =
   | PostgrestSingleResponseSuccess<T>
   | PostgrestResponseFailure
+
 export type PostgrestMaybeSingleResponse<T> = PostgrestSingleResponse<T | null>
 
-export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestResponse<T>> {
+export interface Builder<T> extends PromiseLike<PostgrestResponse<T>> {
+  then<TResult1 = PostgrestResponse<T>, TResult2 = never>(
+    onfulfilled?:
+      | ((value: PostgrestResponse<T>) => TResult1 | PromiseLike<TResult1>)
+      | undefined
+      | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
+  ): PromiseLike<TResult1 | TResult2>
+}
+
+export type ReturnCount = null | 'exact' | 'planned' | 'estimated'
+
+export type ReturnFormat = 'minimal' | 'representation'
+
+export interface SelectOptions {
+  head?: boolean
+  count?: ReturnCount
+}
+
+export interface InsertOptions {
+  upsert?: boolean
+  onConflict?: string
+  returning?: ReturnFormat
+  count?: ReturnCount
+}
+
+export interface UpsertOptions {
+  onConflict?: string
+  returning?: ReturnFormat
+  count?: ReturnCount
+}
+
+export interface UpdateOptions {
+  returning?: ReturnFormat
+  count?: ReturnCount
+}
+
+export interface DeleteOptions {
+  returning?: ReturnFormat
+  count?: ReturnCount
+}
+
+export interface QueryBuilderConfig {
+  headers?: Record<string, string>
+  schema?: string
+}
+
+export interface QueryBuilder<T> {
+  select(columns: string, options?: SelectOptions): FilterBuilder<T>
+
+  insert(values: Partial<T> | Partial<T>[], options?: InsertOptions): FilterBuilder<T>
+
+  upsert(values: Partial<T> | Partial<T>[], options?: UpsertOptions): FilterBuilder<T>
+
+  update(values: Partial<T>, options?: UpdateOptions): FilterBuilder<T>
+
+  delete(options?: DeleteOptions): FilterBuilder<T>
+}
+
+export interface ForeignTableOptions {
+  foreignTable?: string
+}
+
+export type TextSearchType = 'plain' | 'phrase' | 'websearch' | null
+
+export interface TextSearchOptions {
+  config?: string
+  type?: TextSearchType
+}
+
+export interface FilterBuilder<T> {
+  not(column: keyof T, operator: FilterOperator, value: any): FilterBuilder<T>
+
+  or(filters: string, { foreignTable }: ForeignTableOptions): FilterBuilder<T>
+
+  eq(column: keyof T, value: T[keyof T]): FilterBuilder<T>
+
+  neq(column: keyof T, value: T[keyof T]): FilterBuilder<T>
+
+  gt(column: keyof T, value: T[keyof T]): FilterBuilder<T>
+
+  gte(column: keyof T, value: T[keyof T]): FilterBuilder<T>
+
+  lt(column: keyof T, value: T[keyof T]): FilterBuilder<T>
+
+  lte(column: keyof T, value: T[keyof T]): FilterBuilder<T>
+
+  like(column: keyof T, pattern: string): FilterBuilder<T>
+
+  ilike(column: keyof T, pattern: string): FilterBuilder<T>
+
+  is(column: keyof T, value: boolean | null): FilterBuilder<T>
+
+  in(column: keyof T, values: T[keyof T][]): FilterBuilder<T>
+
+  contains(column: keyof T, value: string | T[keyof T][] | object): FilterBuilder<T>
+
+  containedBy(column: keyof T, value: string | T[keyof T][] | object): FilterBuilder<T>
+
+  rangeLt(column: keyof T, range: string): FilterBuilder<T>
+
+  rangeGt(column: keyof T, range: string): FilterBuilder<T>
+
+  rangeGte(column: keyof T, range: string): FilterBuilder<T>
+
+  rangeLte(column: keyof T, range: string): FilterBuilder<T>
+
+  rangeAdjacent(column: keyof T, range: string): FilterBuilder<T>
+
+  overlaps(column: keyof T, value: string | T[keyof T][]): FilterBuilder<T>
+
+  textSearch(column: keyof T, query: string, options: TextSearchOptions): FilterBuilder<T>
+
+  filter(column: keyof T, operator: FilterOperator, value: any): FilterBuilder<T>
+
+  match(query: { [key: string]: string }): FilterBuilder<T>
+}
+
+export interface RpcOptions {
+  count?: ReturnCount
+}
+
+export interface RpcBuilder<T> {
+  rpc(params?: object, options?: RpcOptions): FilterBuilder<T>
+}
+
+export interface OrderOptions {
+  ascending?: boolean
+  nullsFirst?: boolean
+  foreignTable?: string
+}
+
+export interface LimitOptions {
+  foreignTable?: string
+}
+
+export interface RangeOptions {
+  foreignTable?: string
+}
+
+export interface TransformBuilder<T> extends Builder<T> {
+  select(columns?: string): TransformBuilder<T>
+
+  order(column: keyof T, options?: OrderOptions): TransformBuilder<T>
+
+  limit(count: number, options?: LimitOptions): TransformBuilder<T>
+
+  range(from: number, to: number, options?: RangeOptions): TransformBuilder<T>
+
+  single(): PromiseLike<PostgrestSingleResponse<T>>
+
+  maybeSingle(): PromiseLike<PostgrestMaybeSingleResponse<T>>
+
+  csv(): TransformBuilder<T>
+}
+
+export interface ClientConfig {
+  headers?: Record<string, string>
+  schema?: string
+}
+
+export interface Client {
+  url: string
+  headers: Record<string, string>
+  schema?: string
+
+  auth(token: string): Client
+
+  from<T = any>(table: string): QueryBuilder<T>
+
+  rpc<T = any>(fn: string, params?: object): FilterBuilder<T>
+}
+
+export abstract class PostgrestBuilder<T> implements Builder<T> {
   protected method!: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE'
   protected url!: URL
   protected headers!: { [key: string]: string }
@@ -92,7 +296,9 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
           const isReturnMinimal = this.headers['Prefer']?.split(',').includes('return=minimal')
           if (this.method !== 'HEAD' && !isReturnMinimal) {
             const text = await res.text()
-            if (text && text !== '' &&  this.headers['Accept'] !== 'text/csv') data = JSON.parse(text)
+            if (text && text !== '' && this.headers['Accept'] !== 'text/csv') {
+              data = JSON.parse(text)
+            }
           }
 
           const countHeader = this.headers['Prefer']?.match(/count=(exact|planned|estimated)/)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -82,10 +82,10 @@ export type PostgrestMaybeSingleResponse<T> = PostgrestSingleResponse<T | null>
 export interface Builder<T> extends PromiseLike<PostgrestResponse<T>> {
   then<TResult1 = PostgrestResponse<T>, TResult2 = never>(
     onfulfilled?:
-      | ((value: PostgrestResponse<T>) => TResult1 | PromiseLike<TResult1>)
+      | ( (value: PostgrestResponse<T>) => TResult1 | PromiseLike<TResult1> )
       | undefined
       | null,
-    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
+    onrejected?: ( (reason: any) => TResult2 | PromiseLike<TResult2> ) | undefined | null
   ): PromiseLike<TResult1 | TResult2>
 }
 
@@ -201,6 +201,11 @@ export interface RpcOptions {
   count?: ReturnCount
 }
 
+export interface RpcBuilderConfig {
+  headers?: Record<string, string>
+  schema?: string
+}
+
 export interface RpcBuilder<T> {
   rpc(params?: object, options?: RpcOptions): FilterBuilder<T>
 }
@@ -265,17 +270,19 @@ export abstract class PostgrestBuilder<T> implements Builder<T> {
 
   then<TResult1 = PostgrestResponse<T>, TResult2 = never>(
     onfulfilled?:
-      | ((value: PostgrestResponse<T>) => TResult1 | PromiseLike<TResult1>)
+      | ( (value: PostgrestResponse<T>) => TResult1 | PromiseLike<TResult1> )
       | undefined
       | null,
-    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
+    onrejected?: ( (reason: any) => TResult2 | PromiseLike<TResult2> ) | undefined | null
   ): PromiseLike<TResult1 | TResult2> {
     // https://postgrest.org/en/stable/api.html#switching-schemas
     if (typeof this.schema === 'undefined') {
       // skip
-    } else if (['GET', 'HEAD'].includes(this.method)) {
+    }
+    else if ([ 'GET', 'HEAD' ].includes(this.method)) {
       this.headers['Accept-Profile'] = this.schema
-    } else {
+    }
+    else {
       this.headers['Content-Profile'] = this.schema
     }
     if (this.method !== 'GET' && this.method !== 'HEAD') {
@@ -285,7 +292,7 @@ export abstract class PostgrestBuilder<T> implements Builder<T> {
     return fetch(this.url.toString(), {
       method: this.method,
       headers: this.headers,
-      body: JSON.stringify(this.body),
+      body: JSON.stringify(this.body)
     })
       .then(async (res) => {
         let error = null
@@ -306,7 +313,8 @@ export abstract class PostgrestBuilder<T> implements Builder<T> {
           if (countHeader && contentRange && contentRange.length > 1) {
             count = parseInt(contentRange[1])
           }
-        } else {
+        }
+        else {
           error = await res.json()
         }
 
@@ -316,7 +324,7 @@ export abstract class PostgrestBuilder<T> implements Builder<T> {
           count,
           status: res.status,
           statusText: res.statusText,
-          body: data,
+          body: data
         }
         return postgrestResponse
       })

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -82,10 +82,10 @@ export type PostgrestMaybeSingleResponse<T> = PostgrestSingleResponse<T | null>
 export interface Builder<T> extends PromiseLike<PostgrestResponse<T>> {
   then<TResult1 = PostgrestResponse<T>, TResult2 = never>(
     onfulfilled?:
-      | ( (value: PostgrestResponse<T>) => TResult1 | PromiseLike<TResult1> )
+      | ((value: PostgrestResponse<T>) => TResult1 | PromiseLike<TResult1>)
       | undefined
       | null,
-    onrejected?: ( (reason: any) => TResult2 | PromiseLike<TResult2> ) | undefined | null
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
   ): PromiseLike<TResult1 | TResult2>
 }
 
@@ -127,7 +127,7 @@ export interface QueryBuilderConfig {
 }
 
 export interface QueryBuilder<T> {
-  select(columns: string, options?: SelectOptions): FilterBuilder<T>
+  select(columns?: string, options?: SelectOptions): FilterBuilder<T>
 
   insert(values: Partial<T> | Partial<T>[], options?: InsertOptions): FilterBuilder<T>
 
@@ -270,19 +270,17 @@ export abstract class PostgrestBuilder<T> implements Builder<T> {
 
   then<TResult1 = PostgrestResponse<T>, TResult2 = never>(
     onfulfilled?:
-      | ( (value: PostgrestResponse<T>) => TResult1 | PromiseLike<TResult1> )
+      | ((value: PostgrestResponse<T>) => TResult1 | PromiseLike<TResult1>)
       | undefined
       | null,
-    onrejected?: ( (reason: any) => TResult2 | PromiseLike<TResult2> ) | undefined | null
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
   ): PromiseLike<TResult1 | TResult2> {
     // https://postgrest.org/en/stable/api.html#switching-schemas
     if (typeof this.schema === 'undefined') {
       // skip
-    }
-    else if ([ 'GET', 'HEAD' ].includes(this.method)) {
+    } else if (['GET', 'HEAD'].includes(this.method)) {
       this.headers['Accept-Profile'] = this.schema
-    }
-    else {
+    } else {
       this.headers['Content-Profile'] = this.schema
     }
     if (this.method !== 'GET' && this.method !== 'HEAD') {
@@ -292,7 +290,7 @@ export abstract class PostgrestBuilder<T> implements Builder<T> {
     return fetch(this.url.toString(), {
       method: this.method,
       headers: this.headers,
-      body: JSON.stringify(this.body)
+      body: JSON.stringify(this.body),
     })
       .then(async (res) => {
         let error = null
@@ -313,8 +311,7 @@ export abstract class PostgrestBuilder<T> implements Builder<T> {
           if (countHeader && contentRange && contentRange.length > 1) {
             count = parseInt(contentRange[1])
           }
-        }
-        else {
+        } else {
           error = await res.json()
         }
 
@@ -324,7 +321,7 @@ export abstract class PostgrestBuilder<T> implements Builder<T> {
           count,
           status: res.status,
           statusText: res.statusText,
-          body: data
+          body: data,
         }
         return postgrestResponse
       })


### PR DESCRIPTION
- Exports all existing un-exported types (addresses https://github.com/supabase/supabase-js/issues/168) 
- Implements specific types for previously inlined types _(eg options)_
- Implements interfaces rather than concrete _("Program to an interface, not an implementation")_
- Consolidates dangling `FilterOperator` type to `types.ts`

## What kind of change does this PR introduce?

Feature > TypeScript Types

## What is the current behavior?

The package does not presently export all types and contains some concrete typings without interfaces:
https://github.com/supabase/supabase-js/issues/168

## What is the new behavior?

Exports all types and adds interfaces for all previously un-typed classes.
 
