### PR TITLE
feat: add ignoreDuplicates option to upsert

### DIFF
--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -125,6 +125,7 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
    * @param onConflict  By specifying the `on_conflict` query parameter, you can make UPSERT work on a column(s) that has a UNIQUE constraint.
    * @param returning  By default the new record is returned. Set this to 'minimal' if you don't need this value.
    * @param count  Count algorithm to use to count rows in a table.
+   * @param ignoreDuplicates  Specifies if duplicate rows should be ignored and not inserted.
    */
   upsert(
     values: Partial<T> | Partial<T>[],
@@ -132,15 +133,20 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
       onConflict,
       returning = 'representation',
       count = null,
+      ignoreDuplicates = false,
     }: {
       onConflict?: string
       returning?: 'minimal' | 'representation'
       count?: null | 'exact' | 'planned' | 'estimated'
+      ignoreDuplicates?: boolean
     } = {}
   ): PostgrestFilterBuilder<T> {
     this.method = 'POST'
 
-    const prefersHeaders = ['resolution=merge-duplicates', `return=${returning}`]
+    const prefersHeaders = [
+      `resolution=${ignoreDuplicates ? 'ignore' : 'merge'}-duplicates`,
+      `return=${returning}`,
+    ]
 
     if (onConflict !== undefined) this.url.searchParams.set('on_conflict', onConflict)
     this.body = values

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1122,6 +1122,17 @@ Object {
 }
 `;
 
+exports[`ignoreDuplicates upsert 1`] = `
+Object {
+  "body": Array [],
+  "count": null,
+  "data": Array [],
+  "error": null,
+  "status": 201,
+  "statusText": "Created",
+}
+`;
+
 exports[`insert, update, delete with count: 'exact' basic delete count: 'exact' 1`] = `
 Object {
   "body": Array [

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -41,6 +41,13 @@ test('on_conflict insert', async () => {
   expect(res).toMatchSnapshot()
 })
 
+test('ignoreDuplicates upsert', async () => {
+  const res = await postgrest
+    .from('users')
+    .upsert({ username: 'dragarcia' }, { onConflict: 'username', ignoreDuplicates: true })
+  expect(res).toMatchSnapshot()
+})
+
 describe('basic insert, update, delete', () => {
   test('basic insert', async () => {
     let res = await postgrest


### PR DESCRIPTION
## What kind of change does this PR introduce?

As requested (https://github.com/supabase/supabase/discussions/1834 & https://github.com/supabase/postgrest-js/issues/189) this PR implements the `Prefer: resolution=ignore-duplicates` header to ignore duplicates in an upsert operation.

More information on the `Prefer: resolution=ignore-duplicates` header can be found here: https://postgrest.org/en/stable/api.html#upsert

## What is the current behavior?

Currently not implemented so the only option for an upsert is for it to be merged.

## What is the new behavior?

Now users have the option to ignore duplicates instead of merging them.