### PR TITLE
fix: escape `columns` query param

### DIFF
--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -110,7 +110,7 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
     if (Array.isArray(values)) {
       const columns = values.reduce((acc, x) => acc.concat(Object.keys(x)), [] as string[])
       if (columns.length > 0) {
-        const uniqueColumns = [...new Set(columns)]
+        const uniqueColumns = [...new Set(columns)].map((column) => `"${column}"`)
         this.url.searchParams.set('columns', uniqueColumns.join(','))
       }
     }

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -270,7 +270,9 @@ describe("insert, update, delete with count: 'exact'", () => {
 
 test('insert includes columns param', async () => {
   const client = postgrest.from('users').insert([{ foo: 1 }, { bar: 2 }])
-  expect((client as any).url.searchParams.get('columns')).toMatchInlineSnapshot(`"foo,bar"`)
+  expect((client as any).url.searchParams.get('columns')).toMatchInlineSnapshot(
+    `"\\"foo\\",\\"bar\\""`
+  )
 })
 
 test('insert w/ empty body has no columns param', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Can't use `(`, `)`, and other symbols in bulk insert.

## What is the new behavior?

Escape `columns` query param so it can be done.