### PR TITLE
maybeSingle: Avoid uncaught promise rejection

### DIFF
--- a/src/lib/PostgrestTransformBuilder.ts
+++ b/src/lib/PostgrestTransformBuilder.ts
@@ -104,7 +104,7 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
     const _this = new PostgrestTransformBuilder(this)
     _this.then = ((onfulfilled: any, onrejected: any) =>
       this.then((res: any): any => {
-        if (res.error?.details.includes('Results contain 0 rows')) {
+        if (res.error?.details?.includes('Results contain 0 rows')) {
           return onfulfilled({
             error: null,
             data: null,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Not all errors returned by postgrest contain the `details` field (in particular, 401 errors due to invalid/expired JWT tokens). Hence, this PR avoids an uncaught promise rejection by ensuring that `error.details` field exists before checking the error details for the "Results contain 0 rows" message.

## What is the current behavior?

If the result from postgrest has an error status code, and the error response does not have the `details` field, an uncaught rejection will be thrown when used with the `maybeSingle()` modifier.

## What is the new behavior?

The commit avoids throwing such errors by ensuring the `details` field exists.

## Additional context

Nil

**Note:** I didn't run the existing tests as I didn't have Docker setup on my device. Do let me know if I should add additional tests for this as well.