### PR TITLE
Allow customizing RPC request method

### DIFF
--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -49,20 +49,17 @@ export default class PostgrestClient {
    *
    * @param fn  The function name to call.
    * @param params  The parameters to pass to the function call.
+   * @param head  When set to true, no data will be returned.
    * @param count  Count algorithm to use to count rows in a table.
-   * @param method  The HTTP request method the query is sent with.
-   *                "HEAD"/"GET" queries will invoke the function in a read-only transaction.
-   *                "HEAD" can be used with `count` to get the number of rows in a table
-   *                without returning any data.
    */
   rpc<T = any>(
     fn: string,
     params?: object,
     {
-      method = 'POST',
+      head = false,
       count = null,
     }: {
-      method?: 'POST' | 'GET' | 'HEAD'
+      head?: boolean
       count?: null | 'exact' | 'planned' | 'estimated'
     } = {}
   ): PostgrestFilterBuilder<T> {
@@ -70,6 +67,6 @@ export default class PostgrestClient {
     return new PostgrestRpcBuilder<T>(url, {
       headers: this.headers,
       schema: this.schema,
-    }).rpc(params, { method, count })
+    }).rpc(params, { head, count })
   }
 }

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -55,8 +55,10 @@ export default class PostgrestClient {
     fn: string,
     params?: object,
     {
+      method = 'POST',
       count = null,
     }: {
+      method?: 'POST' | 'GET' | 'HEAD'
       count?: null | 'exact' | 'planned' | 'estimated'
     } = {}
   ): PostgrestFilterBuilder<T> {
@@ -64,6 +66,6 @@ export default class PostgrestClient {
     return new PostgrestRpcBuilder<T>(url, {
       headers: this.headers,
       schema: this.schema,
-    }).rpc(params, { count })
+    }).rpc(params, { method, count })
   }
 }

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -50,6 +50,10 @@ export default class PostgrestClient {
    * @param fn  The function name to call.
    * @param params  The parameters to pass to the function call.
    * @param count  Count algorithm to use to count rows in a table.
+   * @param method  The HTTP request method the query is sent with.
+   *                "HEAD"/"GET" queries will invoke the function in a read-only transaction.
+   *                "HEAD" can be used with `count` to get the number of rows in a table
+   *                without returning any data.
    */
   rpc<T = any>(
     fn: string,

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -18,13 +18,25 @@ export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
   rpc(
     params?: object,
     {
+      method = 'POST',
       count = null,
     }: {
+      method?: 'POST' | 'GET' | 'HEAD'
       count?: null | 'exact' | 'planned' | 'estimated'
     } = {}
   ): PostgrestFilterBuilder<T> {
-    this.method = 'POST'
-    this.body = params
+    if (method == 'HEAD' || method == 'GET') {
+      this.method = method
+
+      if (params) {
+        Object.entries(params).forEach(([name, value]) => {
+          this.url.searchParams.append(name, value)
+        })
+      }
+    } else {
+      this.method = 'POST'
+      this.body = params
+    }
 
     if (count) {
       if (this.headers['Prefer'] !== undefined) this.headers['Prefer'] += `,count=${count}`

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -18,15 +18,15 @@ export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
   rpc(
     params?: object,
     {
-      method = 'POST',
+      head = false,
       count = null,
     }: {
-      method?: 'POST' | 'GET' | 'HEAD'
+      head?: boolean
       count?: null | 'exact' | 'planned' | 'estimated'
     } = {}
   ): PostgrestFilterBuilder<T> {
-    if (method == 'HEAD' || method == 'GET') {
-      this.method = method
+    if (head) {
+      this.method = 'HEAD'
 
       if (params) {
         Object.entries(params).forEach(([name, value]) => {

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1993,6 +1993,28 @@ Object {
 }
 `;
 
+exports[`rpc with GET request 1`] = `
+Object {
+  "body": "ONLINE",
+  "count": null,
+  "data": "ONLINE",
+  "error": null,
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
+exports[`rpc with HEAD request 1`] = `
+Object {
+  "body": null,
+  "count": 1,
+  "data": null,
+  "error": null,
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
 exports[`rpc with count: 'exact' 1`] = `
 Object {
   "body": "ONLINE",

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1993,33 +1993,22 @@ Object {
 }
 `;
 
-exports[`rpc with GET request 1`] = `
-Object {
-  "body": "ONLINE",
-  "count": null,
-  "data": "ONLINE",
-  "error": null,
-  "status": 200,
-  "statusText": "OK",
-}
-`;
-
-exports[`rpc with HEAD request 1`] = `
-Object {
-  "body": null,
-  "count": 1,
-  "data": null,
-  "error": null,
-  "status": 200,
-  "statusText": "OK",
-}
-`;
-
 exports[`rpc with count: 'exact' 1`] = `
 Object {
   "body": "ONLINE",
   "count": 1,
   "data": "ONLINE",
+  "error": null,
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
+exports[`rpc with head:true, count:exact 1`] = `
+Object {
+  "body": null,
+  "count": 1,
+  "data": null,
   "error": null,
   "status": 200,
   "statusText": "OK",

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -13,6 +13,20 @@ test('rpc', async () => {
   expect(res).toMatchSnapshot()
 })
 
+test('rpc with GET request', async () => {
+  const res = await postgrest.rpc('get_status', { name_param: 'supabot' }, { method: 'GET' })
+  expect(res).toMatchSnapshot()
+})
+
+test('rpc with HEAD request', async () => {
+  const res = await postgrest.rpc(
+    'get_status',
+    { name_param: 'supabot' },
+    { method: 'HEAD', count: 'exact' }
+  )
+  expect(res).toMatchSnapshot()
+})
+
 test('rpc returns void', async () => {
   const res = await postgrest.rpc('void_func')
   expect(res).toMatchSnapshot()

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -13,20 +13,6 @@ test('rpc', async () => {
   expect(res).toMatchSnapshot()
 })
 
-test('rpc with GET request', async () => {
-  const res = await postgrest.rpc('get_status', { name_param: 'supabot' }, { method: 'GET' })
-  expect(res).toMatchSnapshot()
-})
-
-test('rpc with HEAD request', async () => {
-  const res = await postgrest.rpc(
-    'get_status',
-    { name_param: 'supabot' },
-    { method: 'HEAD', count: 'exact' }
-  )
-  expect(res).toMatchSnapshot()
-})
-
 test('rpc returns void', async () => {
   const res = await postgrest.rpc('void_func')
   expect(res).toMatchSnapshot()
@@ -224,6 +210,15 @@ test('select with count:exact', async () => {
 
 test("rpc with count: 'exact'", async () => {
   const res = await postgrest.rpc('get_status', { name_param: 'supabot' }, { count: 'exact' })
+  expect(res).toMatchSnapshot()
+})
+
+test('rpc with head:true, count:exact', async () => {
+  const res = await postgrest.rpc(
+    'get_status',
+    { name_param: 'supabot' },
+    { head: true, count: 'exact' }
+  )
   expect(res).toMatchSnapshot()
 })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "rootDir": "src",
     "sourceMap": true,
     "target": "ES2015",
+    "lib": ["dom", "ES2017"],
 
     "strict": true,
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

RPC function calls are made only using `POST`.

## What is the new behavior?

Users can customize the HTTP request type to ~~`GET` or~~ `HEAD`. This allows for selecting the count of rows in a function call returning a table without selecting any data with the `HEAD` request type and `count` option.

## Implementation Notes

- I made use of `Object.entries`, but if there's any browser compatibility requirements I can just revert to a `for`-`in` loop.
  - This also required editing the `tsconfig.json` to recognize newer ES methods
- I also didn't account for the edge case where an array parameter is passed with a `GET`/`HEAD` request. Seems like there are two possible usages of this: https://postgrest.org/en/v8.0/api.html#calling-functions-with-array-parameters and https://postgrest.org/en/v8.0/api.html#calling-variadic-functions and I'm not sure behaviour which to prefer.