### PR TITLE
feat: allow providing custom fetch implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Package](https://img.shields.io/npm/v/@supabase/postgrest-js)](https://www.npmjs.com/package/@supabase/postgrest-js)
 [![License: MIT](https://img.shields.io/npm/l/@supabase/postgrest-js)](#license)
 
-Isomorphic JavaScript client for [PostgREST](https://postgrest.org). The goal of this library is to make an "ORM-like" restful interface. 
+Isomorphic JavaScript client for [PostgREST](https://postgrest.org). The goal of this library is to make an "ORM-like" restful interface.
 
 Full documentation can be found [here](https://supabase.github.io/postgrest-js/).
 
@@ -29,6 +29,17 @@ const postgrest = new PostgrestClient(REST_URL)
 - insert(): https://supabase.io/docs/reference/javascript/insert
 - update(): https://supabase.io/docs/reference/javascript/update
 - delete(): https://supabase.io/docs/reference/javascript/delete
+
+#### Custom `fetch` implementation
+
+`postgrest-js` uses the [`cross-fetch`](https://www.npmjs.com/package/cross-fetch) library to make HTTP requests, but an alternative `fetch` implementation can be provided as an option. This is most useful in environments where `cross-fetch` is not compatible, for instance Cloudflare Workers:
+
+```js
+import { PostgrestClient } from '@supabase/postgrest-js'
+
+const REST_URL = 'http://localhost:3000'
+const postgrest = new PostgrestClient(REST_URL, { fetch: fetch })
+```
 
 ## License
 

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -2,11 +2,13 @@ import PostgrestQueryBuilder from './lib/PostgrestQueryBuilder'
 import PostgrestRpcBuilder from './lib/PostgrestRpcBuilder'
 import PostgrestFilterBuilder from './lib/PostgrestFilterBuilder'
 import { DEFAULT_HEADERS } from './lib/constants'
+import { Fetch } from './lib/types'
 
 export default class PostgrestClient {
   url: string
   headers: { [key: string]: string }
   schema?: string
+  fetch?: Fetch
 
   /**
    * Creates a PostgREST client.
@@ -17,11 +19,16 @@ export default class PostgrestClient {
    */
   constructor(
     url: string,
-    { headers = {}, schema }: { headers?: { [key: string]: string }; schema?: string } = {}
+    {
+      headers = {},
+      schema,
+      fetch,
+    }: { headers?: { [key: string]: string }; schema?: string; fetch?: Fetch } = {}
   ) {
     this.url = url
     this.headers = { ...DEFAULT_HEADERS, ...headers }
     this.schema = schema
+    this.fetch = fetch
   }
 
   /**
@@ -41,7 +48,11 @@ export default class PostgrestClient {
    */
   from<T = any>(table: string): PostgrestQueryBuilder<T> {
     const url = `${this.url}/${table}`
-    return new PostgrestQueryBuilder<T>(url, { headers: this.headers, schema: this.schema })
+    return new PostgrestQueryBuilder<T>(url, {
+      headers: this.headers,
+      schema: this.schema,
+      fetch: this.fetch,
+    })
   }
 
   /**
@@ -67,6 +78,7 @@ export default class PostgrestClient {
     return new PostgrestRpcBuilder<T>(url, {
       headers: this.headers,
       schema: this.schema,
+      fetch: this.fetch,
     }).rpc(params, { head, count })
   }
 }

--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -1,12 +1,16 @@
-import { PostgrestBuilder } from './types'
+import { Fetch, PostgrestBuilder } from './types'
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 
 export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
   constructor(
     url: string,
-    { headers = {}, schema }: { headers?: { [key: string]: string }; schema?: string } = {}
+    {
+      headers = {},
+      schema,
+      fetch,
+    }: { headers?: { [key: string]: string }; schema?: string; fetch?: Fetch } = {}
   ) {
-    super({} as PostgrestBuilder<T>)
+    super(({ fetch } as unknown) as PostgrestBuilder<T>)
     this.url = new URL(url)
     this.headers = { ...headers }
     this.schema = schema

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -1,12 +1,16 @@
-import { PostgrestBuilder } from './types'
+import { Fetch, PostgrestBuilder } from './types'
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 
 export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
   constructor(
     url: string,
-    { headers = {}, schema }: { headers?: { [key: string]: string }; schema?: string } = {}
+    {
+      headers = {},
+      schema,
+      fetch,
+    }: { headers?: { [key: string]: string }; schema?: string; fetch?: Fetch } = {}
   ) {
-    super({} as PostgrestBuilder<T>)
+    super(({ fetch } as unknown) as PostgrestBuilder<T>)
     this.url = new URL(url)
     this.headers = { ...headers }
     this.schema = schema

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,6 @@
-import fetch from 'cross-fetch'
+import crossFetch from 'cross-fetch'
+
+export type Fetch = typeof fetch
 
 /**
  * Error format
@@ -56,9 +58,11 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
   protected body?: Partial<T> | Partial<T>[]
   protected shouldThrowOnError = false
   protected signal?: AbortSignal
+  protected fetch: Fetch
 
   constructor(builder: PostgrestBuilder<T>) {
     Object.assign(this, builder)
+    this.fetch = builder.fetch || crossFetch
   }
 
   /**
@@ -91,7 +95,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
       this.headers['Content-Type'] = 'application/json'
     }
 
-    let res = fetch(this.url.toString(), {
+    let res = this.fetch(this.url.toString(), {
       method: this.method,
       headers: this.headers,
       body: JSON.stringify(this.body),


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds the ability to provide a custom `fetch` implementation as an option - this is most useful for environments where `cross-fetch` is not supported, for instance Cloudflare Workers or Vercel Edge Functions.

This is related to https://github.com/supabase/supabase-js/issues/154, and I believe a similar option would need to be added to the other libraries using `cross-fetch` before being finally added to `supabase-js`.

## What is the current behavior?

At the moment, `cross-fetch` is always used in all environments.

## What is the new behavior?

There is a new option `fetch` that can be provided to override `cross-fetch` with an alternative library (or the native `fetch`):

```js
import { PostgrestClient } from '@supabase/postgrest-js'

const REST_URL = 'http://localhost:3000'
const postgrest = new PostgrestClient(REST_URL, { fetch: fetch })
```

## Additional context

Wrapped library PRs:

- https://github.com/supabase/postgrest-js/pull/222 (this PR)
- https://github.com/supabase/gotrue-js/pull/168
- https://github.com/supabase/storage-js/pull/24

`supabase-js` PR:

- https://github.com/supabase/supabase-js/pull/297