### PR TITLE
Fix/clean array value on not filter

### DIFF
--- a/src/lib/PostgrestFilterBuilder.ts
+++ b/src/lib/PostgrestFilterBuilder.ts
@@ -59,7 +59,21 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param value  The value to filter with.
    */
   not(column: keyof T, operator: FilterOperator, value: any): this {
-    this.url.searchParams.append(`${column}`, `not.${operator}.${value}`)
+    if (Array.isArray(value)) {
+      // array
+      const cleanedValues = value
+        .map((s) => {
+          // handle postgrest reserved characters
+          // https://postgrest.org/en/v7.0.0/api.html#reserved-characters
+          if (typeof s === 'string' && new RegExp('[,()]').test(s)) return `"${s}"`
+          else return `${s}`
+        })
+        .join(',')
+
+      this.url.searchParams.append(`${column}`, `not.${operator}.(${cleanedValues})`)
+    } else {
+      this.url.searchParams.append(`${column}`, `not.${operator}.${value}`)
+    }
     return this
   }
 

--- a/test/filters.ts
+++ b/test/filters.ts
@@ -36,7 +36,7 @@ test('not', async () => {
   `)
 })
 
-test('not in', async () => {
+test('not in multiple value', async () => {
   const res = await postgrest.from('users').select('status').not('status', 'in', ['OFFLINE', 'ONLINE'])
   expect(res).toMatchInlineSnapshot(`
     Object {
@@ -47,6 +47,40 @@ test('not in', async () => {
       "status": 200,
       "statusText": "OK",
     }
+  `)
+})
+
+test('not in single value', async () => {
+  const res = await postgrest.from('users').select('status').not('status', 'in', ['OFFLINE'])
+  expect(res).toMatchInlineSnapshot(`
+  Object {
+    "body": Array [
+      Object {
+        "status": "ONLINE",
+      },
+      Object {
+        "status": "ONLINE",
+      },
+      Object {
+        "status": "ONLINE",
+      },
+    ],
+    "count": null,
+    "data": Array [
+      Object {
+        "status": "ONLINE",
+      },
+      Object {
+        "status": "ONLINE",
+      },
+      Object {
+        "status": "ONLINE",
+      },
+    ],
+    "error": null,
+    "status": 200,
+    "statusText": "OK",
+  }
   `)
 })
 

--- a/test/filters.ts
+++ b/test/filters.ts
@@ -36,6 +36,20 @@ test('not', async () => {
   `)
 })
 
+test('not in', async () => {
+  const res = await postgrest.from('users').select('status').not('status', 'in', ['OFFLINE', 'ONLINE'])
+  expect(res).toMatchInlineSnapshot(`
+    Object {
+      "body": Array [],
+      "count": null,
+      "data": Array [],
+      "error": null,
+      "status": 200,
+      "statusText": "OK",
+    }
+  `)
+})
+
 test('or', async () => {
   const res = await postgrest
     .from('users')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix on passing array value on `not` filter with `in` operator
Add another test case regarding the fix

## What is the current behavior?

throw an error when we passed array on value param of not filter. e.g. `.not('column', 'in', [1,2,3])`
```
error - unhandledRejection: {
  message: '"failed to parse filter (not.in.)" (line 1, column 8)',
  details: 'unexpected end of input expecting "("'
}
```
Related issue https://github.com/supabase/postgrest-js/issues/196#issue-931130462

## What is the new behavior?

The new behaviour provide us on calling `not` and `in` with array as value

## Additional context

none
