### PR TITLE
fix(docs): update custom fetch example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ const postgrest = new PostgrestClient(REST_URL)
 import { PostgrestClient } from '@supabase/postgrest-js'
 
 const REST_URL = 'http://localhost:3000'
-const postgrest = new PostgrestClient(REST_URL, { fetch: fetch })
+const postgrest = new PostgrestClient(REST_URL, {
+  fetch: (...args) => fetch(...args),
+})
 ```
 
 ## License


### PR DESCRIPTION
## What kind of change does this PR introduce?

This updates the documentation example of providing a custom `fetch` implementation (introduced in https://github.com/supabase/postgrest-js/pull/222). While the previous example was conceptually correct, in most environments it's not possible to assign a native built-in function like `fetch` to an object, as calling it later will attempt to call the native function in the context of the object and throw an `illegal invocation` error.

Creating a new fetch function by binding to the global scope, for instance `fetch.bind(global)` in Node or `fetch.bind(self)` in Cloudflare Workers, fixes this issue, but creating a new arrow function is the most univerally functional example since it doesn't require you to know if `global` is defined or not, so this PR uses that as an example:

```js
{
  fetch: (...args) => fetch(...args),
}
```

## Additional context

This is followup to https://github.com/supabase/postgrest-js/pull/222.
