### PR TITLE
fix: Fetch method can't handle error response that is not a valid JSON

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -124,14 +124,18 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
           count = parseInt(contentRange[1])
         }
       } else {
+        const body = await res.text()
+
         try {
-          error = await res.json()
-        } catch (e) {
-          error = await res.text()
-        } finally {
-          if (error && this.shouldThrowOnError) {
-            throw error
+          error = JSON.parse(body)
+        } catch {
+          error = {
+            message: body
           }
+        }
+
+        if (error && this.shouldThrowOnError) {
+          throw error
         }
       }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -124,10 +124,14 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
           count = parseInt(contentRange[1])
         }
       } else {
-        error = await res.json()
-
-        if (error && this.shouldThrowOnError) {
-          throw error
+        try {
+          error = await res.json()
+        } catch (e) {
+          error = await res.text()
+        } finally {
+          if (error && this.shouldThrowOnError) {
+            throw error
+          }
         }
       }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The fetch method tries to parse error response as JSON before returning. Whenever the error response is not a JSON object, it will not return properly instead a JSON parsing error will be thrown.

## What is the new behavior?

The fetch method tries to parse error response as JSON before returning, in case of failure returns a raw text error.

## Additional context

Fix #241 
