### PR TITLE
feat: support for custom prefer headers #243

### DIFF
--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -108,7 +108,9 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
     if (count) {
       prefersHeaders.push(`count=${count}`)
     }
-
+    if (this.headers['Prefer']) {
+      prefersHeaders.unshift(this.headers['Prefer'])
+    }
     this.headers['Prefer'] = prefersHeaders.join(',')
 
     if (Array.isArray(values)) {
@@ -157,7 +159,9 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
     if (count) {
       prefersHeaders.push(`count=${count}`)
     }
-
+    if (this.headers['Prefer']) {
+      prefersHeaders.unshift(this.headers['Prefer'])
+    }
     this.headers['Prefer'] = prefersHeaders.join(',')
 
     return new PostgrestFilterBuilder(this)
@@ -186,6 +190,9 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
     if (count) {
       prefersHeaders.push(`count=${count}`)
     }
+    if (this.headers['Prefer']) {
+      prefersHeaders.unshift(this.headers['Prefer'])
+    }
     this.headers['Prefer'] = prefersHeaders.join(',')
     return new PostgrestFilterBuilder(this)
   }
@@ -207,6 +214,9 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
     const prefersHeaders = [`return=${returning}`]
     if (count) {
       prefersHeaders.push(`count=${count}`)
+    }
+    if (this.headers['Prefer']) {
+      prefersHeaders.unshift(this.headers['Prefer'])
     }
     this.headers['Prefer'] = prefersHeaders.join(',')
     return new PostgrestFilterBuilder(this)

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -23,6 +23,33 @@ test('custom headers', async () => {
   expect((postgrest.from('users').select() as any).headers['apikey']).toEqual('foo')
 })
 
+describe('custom prefer headers with ', () => {
+  test('insert', async () => {
+    const postgrest = new PostgrestClient(REST_URL, { headers: { Prefer: 'tx=rollback' } })
+    const postgrestFilterBuilder = postgrest.from('users').insert({ username: 'dragarcia' }) as any
+    expect(postgrestFilterBuilder.headers['Prefer']).toContain('tx=rollback')
+    expect(postgrestFilterBuilder.headers['Prefer']).toContain('return=')
+  })
+  test('update', async () => {
+    const postgrest = new PostgrestClient(REST_URL, { headers: { Prefer: 'tx=rollback' } })
+    const postgrestFilterBuilder = postgrest.from('users').update({ username: 'dragarcia' }) as any
+    expect(postgrestFilterBuilder.headers['Prefer']).toContain('tx=rollback')
+    expect(postgrestFilterBuilder.headers['Prefer']).toContain('return=')
+  })
+  test('upsert', async () => {
+    const postgrest = new PostgrestClient(REST_URL, { headers: { Prefer: 'tx=rollback' } })
+    const postgrestFilterBuilder = postgrest.from('users').upsert({ username: 'dragarcia' }) as any
+    expect(postgrestFilterBuilder.headers['Prefer']).toContain('tx=rollback')
+    expect(postgrestFilterBuilder.headers['Prefer']).toContain('return=')
+  })
+  test('delete', async () => {
+    const postgrest = new PostgrestClient(REST_URL, { headers: { Prefer: 'tx=rollback' } })
+    const postgrestFilterBuilder = postgrest.from('users').delete() as any
+    expect(postgrestFilterBuilder.headers['Prefer']).toContain('tx=rollback')
+    expect(postgrestFilterBuilder.headers['Prefer']).toContain('return=')
+  })
+})
+
 test('auth', async () => {
   const postgrest = new PostgrestClient(REST_URL).auth('foo')
   expect((postgrest.from('users').select() as any).headers['Authorization']).toEqual('Bearer foo')


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds the ability to add custom `prefer` headers such as [Prefer: tx=rollback](https://postgrest.org/en/stable/configuration.html#db-tx-end). 

Custom prefer headers will take precedence over the existing `prefer` heaaders.

Bug fix, feature, docs update, ...
#243 

## What is the current behavior?

Current [implementation](https://github.com/supabase/postgrest-js/blob/eab227d2fb0eacd5fc4b1bc355183050a5ca40d9/src/lib/PostgrestQueryBuilder.ts#L112) overwrites custom `Prefer` headers that are passed during client initialisation

## What is the new behavior?

Custom Prefer Headers gets prepended to the existing prefer headers.

