### PR TITLE
feat: support setting throwOnError at the client level

### DIFF
--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -9,6 +9,7 @@ export default class PostgrestClient {
   headers: { [key: string]: string }
   schema?: string
   fetch?: Fetch
+  shouldThrowOnError?: boolean
 
   /**
    * Creates a PostgREST client.
@@ -23,12 +24,19 @@ export default class PostgrestClient {
       headers = {},
       schema,
       fetch,
-    }: { headers?: { [key: string]: string }; schema?: string; fetch?: Fetch } = {}
+      throwOnError,
+    }: {
+      headers?: { [key: string]: string }
+      schema?: string
+      fetch?: Fetch
+      throwOnError?: boolean
+    } = {}
   ) {
     this.url = url
     this.headers = { ...DEFAULT_HEADERS, ...headers }
     this.schema = schema
     this.fetch = fetch
+    this.shouldThrowOnError = throwOnError
   }
 
   /**
@@ -52,6 +60,7 @@ export default class PostgrestClient {
       headers: this.headers,
       schema: this.schema,
       fetch: this.fetch,
+      shouldThrowOnError: this.shouldThrowOnError,
     })
   }
 
@@ -79,6 +88,7 @@ export default class PostgrestClient {
       headers: this.headers,
       schema: this.schema,
       fetch: this.fetch,
+      shouldThrowOnError: this.shouldThrowOnError,
     }).rpc(params, { head, count })
   }
 }

--- a/src/lib/PostgrestQueryBuilder.ts
+++ b/src/lib/PostgrestQueryBuilder.ts
@@ -8,9 +8,15 @@ export default class PostgrestQueryBuilder<T> extends PostgrestBuilder<T> {
       headers = {},
       schema,
       fetch,
-    }: { headers?: { [key: string]: string }; schema?: string; fetch?: Fetch } = {}
+      shouldThrowOnError,
+    }: {
+      headers?: { [key: string]: string }
+      schema?: string
+      fetch?: Fetch
+      shouldThrowOnError?: boolean
+    } = {}
   ) {
-    super(({ fetch } as unknown) as PostgrestBuilder<T>)
+    super({ fetch, shouldThrowOnError } as unknown as PostgrestBuilder<T>)
     this.url = new URL(url)
     this.headers = { ...headers }
     this.schema = schema

--- a/src/lib/PostgrestRpcBuilder.ts
+++ b/src/lib/PostgrestRpcBuilder.ts
@@ -8,9 +8,15 @@ export default class PostgrestRpcBuilder<T> extends PostgrestBuilder<T> {
       headers = {},
       schema,
       fetch,
-    }: { headers?: { [key: string]: string }; schema?: string; fetch?: Fetch } = {}
+      shouldThrowOnError,
+    }: {
+      headers?: { [key: string]: string }
+      schema?: string
+      fetch?: Fetch
+      shouldThrowOnError?: boolean
+    } = {}
   ) {
-    super(({ fetch } as unknown) as PostgrestBuilder<T>)
+    super({ fetch, shouldThrowOnError } as unknown as PostgrestBuilder<T>)
     this.url = new URL(url)
     this.headers = { ...headers }
     this.schema = schema

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,7 +56,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
   protected headers!: { [key: string]: string }
   protected schema?: string
   protected body?: Partial<T> | Partial<T>[]
-  protected shouldThrowOnError = false
+  protected shouldThrowOnError: boolean
   protected signal?: AbortSignal
   protected fetch: Fetch
 
@@ -71,6 +71,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
       _fetch = fetch
     }
     this.fetch = (...args) => _fetch(...args)
+    this.shouldThrowOnError = builder.shouldThrowOnError || false
   }
 
   /**
@@ -79,8 +80,11 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
    *
    * {@link https://github.com/supabase/supabase-js/issues/92}
    */
-  throwOnError(): PostgrestBuilder<T> {
-    this.shouldThrowOnError = true
+  throwOnError(throwOnError?: boolean): PostgrestBuilder<T> {
+    if (throwOnError === null || throwOnError === undefined) {
+      throwOnError = true
+    }
+    this.shouldThrowOnError = throwOnError
     return this
   }
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -2285,6 +2285,31 @@ Object {
 }
 `;
 
+exports[`throwOnError can be disabled per call 1`] = `
+Object {
+  "code": "42P01",
+  "details": null,
+  "hint": null,
+  "message": "relation \\"public.missing_table\\" does not exist",
+}
+`;
+
+exports[`throwOnError setting at the client level - query 1`] = `
+Object {
+  "code": "42P01",
+  "details": null,
+  "hint": null,
+  "message": "relation \\"public.missing_table\\" does not exist",
+}
+`;
+
+exports[`throwOnError setting at the client level - rpc 1`] = `
+Object {
+  "hint": "If a new function was created in the database with this name and parameters, try reloading the schema cache.",
+  "message": "Could not find the public.missing_fn() function or the public.missing_fn function with a single unnamed json or jsonb parameter in the schema cache",
+}
+`;
+
 exports[`throwOnError throws errors instead of returning them 1`] = `
 Object {
   "code": "42P01",

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -142,6 +142,43 @@ test('throwOnError throws errors instead of returning them', async () => {
   expect(isErrorCaught).toBe(true)
 })
 
+test('throwOnError setting at the client level - query', async () => {
+  let isErrorCaught = false
+  const postgrest_ = new PostgrestClient(REST_URL, { throwOnError: true })
+
+  try {
+    await postgrest_.from('missing_table').select()
+  } catch (error) {
+    expect(error).toMatchSnapshot()
+    isErrorCaught = true
+  }
+
+  expect(isErrorCaught).toBe(true)
+})
+
+test('throwOnError setting at the client level - rpc', async () => {
+  let isErrorCaught = false
+  const postgrest_ = new PostgrestClient(REST_URL, { throwOnError: true })
+
+  try {
+    await postgrest_.rpc('missing_fn').select()
+  } catch (error) {
+    expect(error).toMatchSnapshot()
+    isErrorCaught = true
+  }
+
+  expect(isErrorCaught).toBe(true)
+})
+
+test('throwOnError can be disabled per call', async () => {
+  let isErrorCaught = false
+  const postgrest_ = new PostgrestClient(REST_URL, { throwOnError: true })
+  const { error } = await postgrest_.from('missing_table').select().throwOnError(false)
+
+  expect(error).toMatchSnapshot()
+  expect(isErrorCaught).toBe(false)
+})
+
 test('connection error w/o throwing', async () => {
   const postgrest = new PostgrestClient('http://foo.invalid')
   let isErrorCaught = false


### PR DESCRIPTION
Currently, throwOnError can be set to true for any given query (/rpc
call). This change allows the flag to be set to true at client
initialization time, ensuring that you do not need to rely on each
invocation either handling the error returned, or setting the flag
correctly.
