### PR TITLE
fix(types): update throwOnError return type to "this"

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -80,7 +80,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
    *
    * {@link https://github.com/supabase/supabase-js/issues/92}
    */
-  throwOnError(throwOnError?: boolean): PostgrestBuilder<T> {
+  throwOnError(throwOnError?: boolean): this {
     if (throwOnError === null || throwOnError === undefined) {
       throwOnError = true
     }

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -133,7 +133,7 @@ test('throwOnError throws errors instead of returning them', async () => {
   let isErrorCaught = false
 
   try {
-    await postgrest.from('missing_table').select().throwOnError()
+    await postgrest.from('missing_table').throwOnError().select()
   } catch (error) {
     expect(error).toMatchSnapshot()
     isErrorCaught = true


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for typings

## What is the current behavior?

You cannot chain modifiers after `PostgrestBuilder.throwOnError()` because the return type is the base abstract class.

## What is the new behavior?

The return type should be `this` so that you can continue to add modifiers.

## Additional context

Test change indicates the chaining order that is now supported.