### PR TITLE
feat: add toString() method to PostgrestBuilder

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,6 +75,15 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
   }
 
   /**
+   * Returns a stringified copy of the URL with sorted search params
+   */
+  toString() {
+    const copiedURL = new URL(this.url.toString())
+    copiedURL.searchParams.sort()
+    return copiedURL.toString()
+  }
+
+  /**
    * If there's an error with the query, throwOnError will reject the promise by
    * throwing the error instead of returning it as part of a successful response.
    *

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -366,3 +366,10 @@ test('select with no match', async () => {
     }
   `)
 })
+
+test('toString', async () => {
+  const string1 = postgrest.from('users').select('*').or('username.eq.missing').eq('username', 'missing').toString()
+  const string2 = postgrest.from('users').select('*').eq('username', 'missing').or('username.eq.missing').toString()
+  expect(string1).toEqual(string2)
+  expect(string1).toEqual('http://localhost:3000/users?or=%28username.eq.missing%29&select=*&username=eq.missing"')
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Currently calling toString returns `[object Object]` and is thereby not useable as e.g. a cache key in swr, see https://github.com/vercel/swr/issues/1846 for a related issue.

## What is the new behavior?

This PR implements the `toString()` method on the `PostgrestBuilder` that returns a stringified copy of the URL with sorted search params and is thereby independent of the order at which the filters are applied.

## Additional context

This PR does not sort within the filters, e.g. 

```ts
  const string1 = postgrest.from('users').select('*').or('first_name.eq.Peter,username.eq.missing').eq('username', 'missing').toString()
  const string2 = postgrest.from('users').select('*').eq('username', 'missing').or('username.eq.missing,first_name.eq.Peter').toString()
```

would still return different strings. This can be controlled on user-side though and would add unnecessary complexity to the client.
