### PR TITLE
fix: make throwOnError work with maybeSingle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs
 # nyc
 coverage
 .nyc_output
+
+.idea

--- a/src/lib/PostgrestTransformBuilder.ts
+++ b/src/lib/PostgrestTransformBuilder.ts
@@ -109,23 +109,8 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
    */
   maybeSingle(): PromiseLike<PostgrestMaybeSingleResponse<T>> {
     this.headers['Accept'] = 'application/vnd.pgrst.object+json'
-    const _this = new PostgrestTransformBuilder(this)
-    _this.then = ((onfulfilled: any, onrejected: any) =>
-      this.then((res: any): any => {
-        if (res.error?.details?.includes('Results contain 0 rows')) {
-          return onfulfilled({
-            error: null,
-            data: null,
-            count: res.count,
-            status: 200,
-            statusText: 'OK',
-            body: null,
-          })
-        }
-
-        return onfulfilled(res)
-      }, onrejected)) as any
-    return _this as PromiseLike<PostgrestMaybeSingleResponse<T>>
+    this.allowEmpty = true
+    return this as PromiseLike<PostgrestMaybeSingleResponse<T>>
   }
 
   /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -59,6 +59,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
   protected shouldThrowOnError: boolean
   protected signal?: AbortSignal
   protected fetch: Fetch
+  protected allowEmpty: boolean
 
   constructor(builder: PostgrestBuilder<T>) {
     Object.assign(this, builder)
@@ -72,6 +73,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
     }
     this.fetch = (...args) => _fetch(...args)
     this.shouldThrowOnError = builder.shouldThrowOnError || false
+    this.allowEmpty = false
   }
 
   /**
@@ -116,6 +118,8 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
       let error = null
       let data = null
       let count = null
+      let status = res.status
+      let statusText = res.statusText
 
       if (res.ok) {
         const isReturnMinimal = this.headers['Prefer']?.split(',').includes('return=minimal')
@@ -146,6 +150,12 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
           }
         }
 
+        if (error && this.allowEmpty && error?.details?.includes('Results contain 0 rows')) {
+          error = null
+          status = 200
+          statusText = 'OK'
+        }
+
         if (error && this.shouldThrowOnError) {
           throw error
         }
@@ -155,8 +165,8 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
         error,
         data,
         count,
-        status: res.status,
-        statusText: res.statusText,
+        status,
+        statusText,
         body: data,
       }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -73,7 +73,7 @@ export abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestRespon
     }
     this.fetch = (...args) => _fetch(...args)
     this.shouldThrowOnError = builder.shouldThrowOnError || false
-    this.allowEmpty = false
+    this.allowEmpty = builder.allowEmpty || false
   }
 
   /**

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -204,6 +204,20 @@ test('connection error w/ throwOnError', async () => {
   expect(isErrorCaught).toBe(true)
 })
 
+test('maybeSingle w/ throwOnError', async () => {
+  let passes = true
+  await postgrest
+    .from('messages')
+    .select()
+    .eq('message', 'i do not exist')
+    .throwOnError(true)
+    .maybeSingle()
+    .then(undefined, () => {
+      passes = false
+    })
+  expect(passes).toEqual(true)
+})
+
 test('custom type', async () => {
   interface User {
     username: string


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug Fix

closes #271 

## What is the current behavior?

Currently, `throwOnError()` throws if empty results are received despite `maybeSingle()`. See #271 for details.

## What is the new behavior?

```ts
const { data, error } = await supabaseClient
  .from('channel')
  .update({ active: false })
  .eq('id', channelId)
  .throwOnError(true)
  .maybeSingle(); 
console.error(error) // null, and no error is thrown
```

