### PR TITLE
perf: nullsFirst = true by default

### DIFF
--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -46,7 +46,7 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
     column: keyof T,
     {
       ascending = true,
-      nullsFirst = false,
+      nullsFirst = true,
       foreignTable,
     }: { ascending?: boolean; nullsFirst?: boolean; foreignTable?: string } = {}
   ): this {


### PR DESCRIPTION
BREAKING CHANGE: nullsFirst = true by default

We previously set `nullsFirst = false` by default, but it caused some perf issues: https://github.com/supabase/postgrest-js/issues/239