### PR TITLE
Improved typings

### DIFF
--- a/src/PostgrestBuilder.ts
+++ b/src/PostgrestBuilder.ts
@@ -2,18 +2,20 @@ import crossFetch from 'cross-fetch'
 
 import type { Fetch, PostgrestResponse } from './types'
 
-export default abstract class PostgrestBuilder<T> implements PromiseLike<PostgrestResponse<T>> {
+export default abstract class PostgrestBuilder<Result>
+  implements PromiseLike<PostgrestResponse<Result>>
+{
   protected method: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE'
   protected url: URL
   protected headers: Record<string, string>
   protected schema?: string
-  protected body?: Partial<T> | Partial<T>[]
+  protected body?: unknown
   protected shouldThrowOnError: boolean
   protected signal?: AbortSignal
   protected fetch: Fetch
   protected allowEmpty: boolean
 
-  constructor(builder: PostgrestBuilder<T>) {
+  constructor(builder: PostgrestBuilder<Result>) {
     this.method = builder.method
     this.url = builder.url
     this.headers = builder.headers
@@ -45,9 +47,9 @@ export default abstract class PostgrestBuilder<T> implements PromiseLike<Postgre
     return this
   }
 
-  then<TResult1 = PostgrestResponse<T>, TResult2 = never>(
+  then<TResult1 = PostgrestResponse<Result>, TResult2 = never>(
     onfulfilled?:
-      | ((value: PostgrestResponse<T>) => TResult1 | PromiseLike<TResult1>)
+      | ((value: PostgrestResponse<Result>) => TResult1 | PromiseLike<TResult1>)
       | undefined
       | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null

--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -43,7 +43,9 @@ export default class PostgrestFilterBuilder<
     column: ColumnName,
     operator: FilterOperator,
     value: Table[ColumnName]
-  ): this {
+  ): this
+  not(column: string, operator: string, value: unknown): this
+  not(column: string, operator: string, value: unknown): this {
     this.url.searchParams.append(column, `not.${operator}.${value}`)
     return this
   }
@@ -55,7 +57,7 @@ export default class PostgrestFilterBuilder<
    * @param foreignTable  The foreign table to use (if `column` is a foreign column).
    */
   or(filters: string, { foreignTable }: { foreignTable?: string } = {}): this {
-    const key = typeof foreignTable === 'undefined' ? 'or' : `${foreignTable}.or`
+    const key = foreignTable ? `${foreignTable}.or` : 'or'
     this.url.searchParams.append(key, `(${filters})`)
     return this
   }
@@ -67,7 +69,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  eq<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this {
+  eq<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this
+  eq(column: string, value: unknown): this
+  eq(column: string, value: unknown): this {
     this.url.searchParams.append(column, `eq.${value}`)
     return this
   }
@@ -79,7 +83,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  neq<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this {
+  neq<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this
+  neq(column: string, value: unknown): this
+  neq(column: string, value: unknown): this {
     this.url.searchParams.append(column, `neq.${value}`)
     return this
   }
@@ -91,7 +97,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  gt<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this {
+  gt<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this
+  gt(column: string, value: unknown): this
+  gt(column: string, value: unknown): this {
     this.url.searchParams.append(column, `gt.${value}`)
     return this
   }
@@ -103,7 +111,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  gte<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this {
+  gte<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this
+  gte(column: string, value: unknown): this
+  gte(column: string, value: unknown): this {
     this.url.searchParams.append(column, `gte.${value}`)
     return this
   }
@@ -115,7 +125,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  lt<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this {
+  lt<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this
+  lt(column: string, value: unknown): this
+  lt(column: string, value: unknown): this {
     this.url.searchParams.append(column, `lt.${value}`)
     return this
   }
@@ -127,7 +139,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  lte<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this {
+  lte<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this
+  lte(column: string, value: unknown): this
+  lte(column: string, value: unknown): this {
     this.url.searchParams.append(column, `lte.${value}`)
     return this
   }
@@ -139,7 +153,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param pattern  The pattern to filter with.
    */
-  like<ColumnName extends string & keyof Table>(column: ColumnName, pattern: string): this {
+  like<ColumnName extends string & keyof Table>(column: ColumnName, pattern: string): this
+  like(column: string, pattern: string): this
+  like(column: string, pattern: string): this {
     this.url.searchParams.append(column, `like.${pattern}`)
     return this
   }
@@ -151,7 +167,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param pattern  The pattern to filter with.
    */
-  ilike<ColumnName extends string & keyof Table>(column: ColumnName, pattern: string): this {
+  ilike<ColumnName extends string & keyof Table>(column: ColumnName, pattern: string): this
+  ilike(column: string, pattern: string): this
+  ilike(column: string, pattern: string): this {
     this.url.searchParams.append(column, `ilike.${pattern}`)
     return this
   }
@@ -166,7 +184,9 @@ export default class PostgrestFilterBuilder<
   is<ColumnName extends string & keyof Table>(
     column: ColumnName,
     value: Table[ColumnName] & (boolean | null)
-  ): this {
+  ): this
+  is(column: string, value: boolean | null): this
+  is(column: string, value: boolean | null): this {
     this.url.searchParams.append(column, `is.${value}`)
     return this
   }
@@ -178,10 +198,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param values  The values to filter with.
    */
-  in<ColumnName extends string & keyof Table>(
-    column: ColumnName,
-    values: Table[ColumnName][]
-  ): this {
+  in<ColumnName extends string & keyof Table>(column: ColumnName, values: Table[ColumnName][]): this
+  in(column: string, values: unknown[]): this
+  in(column: string, values: unknown[]): this {
     const cleanedValues = values
       .map((s) => {
         // handle postgrest reserved characters
@@ -204,7 +223,9 @@ export default class PostgrestFilterBuilder<
   contains<ColumnName extends string & keyof Table>(
     column: ColumnName,
     value: string | Table[ColumnName][] | Record<string, unknown>
-  ): this {
+  ): this
+  contains(column: string, value: string | unknown[] | Record<string, unknown>): this
+  contains(column: string, value: string | unknown[] | Record<string, unknown>): this {
     if (typeof value === 'string') {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
       // keep it simple and accept a string
@@ -229,7 +250,9 @@ export default class PostgrestFilterBuilder<
   containedBy<ColumnName extends string & keyof Table>(
     column: ColumnName,
     value: string | Table[ColumnName][] | Record<string, unknown>
-  ): this {
+  ): this
+  containedBy(column: string, value: string | unknown[] | Record<string, unknown>): this
+  containedBy(column: string, value: string | unknown[] | Record<string, unknown>): this {
     if (typeof value === 'string') {
       // range
       this.url.searchParams.append(column, `cd.${value}`)
@@ -250,7 +273,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeLt<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this {
+  rangeLt<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this
+  rangeLt(column: string, range: string): this
+  rangeLt(column: string, range: string): this {
     this.url.searchParams.append(column, `sl.${range}`)
     return this
   }
@@ -262,7 +287,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeGt<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this {
+  rangeGt<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this
+  rangeGt(column: string, range: string): this
+  rangeGt(column: string, range: string): this {
     this.url.searchParams.append(column, `sr.${range}`)
     return this
   }
@@ -274,7 +301,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeGte<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this {
+  rangeGte<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this
+  rangeGte(column: string, range: string): this
+  rangeGte(column: string, range: string): this {
     this.url.searchParams.append(column, `nxl.${range}`)
     return this
   }
@@ -286,7 +315,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeLte<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this {
+  rangeLte<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this
+  rangeLte(column: string, range: string): this
+  rangeLte(column: string, range: string): this {
     this.url.searchParams.append(column, `nxr.${range}`)
     return this
   }
@@ -298,7 +329,9 @@ export default class PostgrestFilterBuilder<
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeAdjacent<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this {
+  rangeAdjacent<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this
+  rangeAdjacent(column: string, range: string): this
+  rangeAdjacent(column: string, range: string): this {
     this.url.searchParams.append(column, `adj.${range}`)
     return this
   }
@@ -313,7 +346,9 @@ export default class PostgrestFilterBuilder<
   overlaps<ColumnName extends string & keyof Table>(
     column: ColumnName,
     value: string | Table[ColumnName][]
-  ): this {
+  ): this
+  overlaps(column: string, value: string | unknown[]): this
+  overlaps(column: string, value: string | unknown[]): this {
     if (typeof value === 'string') {
       // range
       this.url.searchParams.append(column, `ov.${value}`)
@@ -335,6 +370,16 @@ export default class PostgrestFilterBuilder<
    */
   textSearch<ColumnName extends string & keyof Table>(
     column: ColumnName,
+    query: string,
+    options?: { config?: string; type?: 'plain' | 'phrase' | 'websearch' }
+  ): this
+  textSearch(
+    column: string,
+    query: string,
+    options?: { config?: string; type?: 'plain' | 'phrase' | 'websearch' }
+  ): this
+  textSearch(
+    column: string,
     query: string,
     { config, type }: { config?: string; type?: 'plain' | 'phrase' | 'websearch' } = {}
   ): this {
@@ -361,8 +406,10 @@ export default class PostgrestFilterBuilder<
   filter<ColumnName extends string & keyof Table>(
     column: ColumnName,
     operator: `${'' | 'not.'}${FilterOperator}`,
-    value: any
-  ): this {
+    value: unknown
+  ): this
+  filter(column: string, operator: string, value: unknown): this
+  filter(column: string, operator: string, value: unknown): this {
     this.url.searchParams.append(column, `${operator}.${value}`)
     return this
   }
@@ -373,9 +420,9 @@ export default class PostgrestFilterBuilder<
    * @param query  The object to filter with, with column names as keys mapped
    *               to their filter values.
    */
-  match<ColumnName extends string & keyof Table>(
-    query: Record<ColumnName, Table[ColumnName]>
-  ): this {
+  match<ColumnName extends string & keyof Table>(query: Record<ColumnName, Table[ColumnName]>): this
+  match(query: Record<string, unknown>): this
+  match(query: Record<string, unknown>): this {
     Object.entries(query).forEach(([column, value]) => {
       this.url.searchParams.append(column, `eq.${value}`)
     })

--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -28,7 +28,10 @@ type FilterOperator =
   | 'phfts'
   | 'wfts'
 
-export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
+export default class PostgrestFilterBuilder<
+  Table extends Record<string, unknown>,
+  Result
+> extends PostgrestTransformBuilder<Table, Result> {
   /**
    * Finds all rows which doesn't satisfy the filter.
    *
@@ -36,8 +39,12 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param operator  The operator to filter with.
    * @param value  The value to filter with.
    */
-  not(column: keyof T, operator: FilterOperator, value: any): this {
-    this.url.searchParams.append(`${column}`, `not.${operator}.${value}`)
+  not<ColumnName extends string & keyof Table>(
+    column: ColumnName,
+    operator: FilterOperator,
+    value: Table[ColumnName]
+  ): this {
+    this.url.searchParams.append(column, `not.${operator}.${value}`)
     return this
   }
 
@@ -60,8 +67,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  eq(column: keyof T, value: T[keyof T]): this {
-    this.url.searchParams.append(`${column}`, `eq.${value}`)
+  eq<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this {
+    this.url.searchParams.append(column, `eq.${value}`)
     return this
   }
 
@@ -72,8 +79,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  neq(column: keyof T, value: T[keyof T]): this {
-    this.url.searchParams.append(`${column}`, `neq.${value}`)
+  neq<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this {
+    this.url.searchParams.append(column, `neq.${value}`)
     return this
   }
 
@@ -84,8 +91,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  gt(column: keyof T, value: T[keyof T]): this {
-    this.url.searchParams.append(`${column}`, `gt.${value}`)
+  gt<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this {
+    this.url.searchParams.append(column, `gt.${value}`)
     return this
   }
 
@@ -96,8 +103,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  gte(column: keyof T, value: T[keyof T]): this {
-    this.url.searchParams.append(`${column}`, `gte.${value}`)
+  gte<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this {
+    this.url.searchParams.append(column, `gte.${value}`)
     return this
   }
 
@@ -108,8 +115,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  lt(column: keyof T, value: T[keyof T]): this {
-    this.url.searchParams.append(`${column}`, `lt.${value}`)
+  lt<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this {
+    this.url.searchParams.append(column, `lt.${value}`)
     return this
   }
 
@@ -120,8 +127,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  lte(column: keyof T, value: T[keyof T]): this {
-    this.url.searchParams.append(`${column}`, `lte.${value}`)
+  lte<ColumnName extends string & keyof Table>(column: ColumnName, value: Table[ColumnName]): this {
+    this.url.searchParams.append(column, `lte.${value}`)
     return this
   }
 
@@ -132,8 +139,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param pattern  The pattern to filter with.
    */
-  like(column: keyof T, pattern: string): this {
-    this.url.searchParams.append(`${column}`, `like.${pattern}`)
+  like<ColumnName extends string & keyof Table>(column: ColumnName, pattern: string): this {
+    this.url.searchParams.append(column, `like.${pattern}`)
     return this
   }
 
@@ -144,8 +151,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param pattern  The pattern to filter with.
    */
-  ilike(column: keyof T, pattern: string): this {
-    this.url.searchParams.append(`${column}`, `ilike.${pattern}`)
+  ilike<ColumnName extends string & keyof Table>(column: ColumnName, pattern: string): this {
+    this.url.searchParams.append(column, `ilike.${pattern}`)
     return this
   }
 
@@ -156,8 +163,11 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  is(column: keyof T, value: boolean | null): this {
-    this.url.searchParams.append(`${column}`, `is.${value}`)
+  is<ColumnName extends string & keyof Table>(
+    column: ColumnName,
+    value: Table[ColumnName] & (boolean | null)
+  ): this {
+    this.url.searchParams.append(column, `is.${value}`)
     return this
   }
 
@@ -168,7 +178,10 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param values  The values to filter with.
    */
-  in(column: keyof T, values: T[keyof T][]): this {
+  in<ColumnName extends string & keyof Table>(
+    column: ColumnName,
+    values: Table[ColumnName][]
+  ): this {
     const cleanedValues = values
       .map((s) => {
         // handle postgrest reserved characters
@@ -177,7 +190,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
         else return `${s}`
       })
       .join(',')
-    this.url.searchParams.append(`${column}`, `in.(${cleanedValues})`)
+    this.url.searchParams.append(column, `in.(${cleanedValues})`)
     return this
   }
 
@@ -188,17 +201,20 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  contains(column: keyof T, value: string | T[keyof T][] | object): this {
+  contains<ColumnName extends string & keyof Table>(
+    column: ColumnName,
+    value: string | Table[ColumnName][] | Record<string, unknown>
+  ): this {
     if (typeof value === 'string') {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
       // keep it simple and accept a string
-      this.url.searchParams.append(`${column}`, `cs.${value}`)
+      this.url.searchParams.append(column, `cs.${value}`)
     } else if (Array.isArray(value)) {
       // array
-      this.url.searchParams.append(`${column}`, `cs.{${value.join(',')}}`)
+      this.url.searchParams.append(column, `cs.{${value.join(',')}}`)
     } else {
       // json
-      this.url.searchParams.append(`${column}`, `cs.${JSON.stringify(value)}`)
+      this.url.searchParams.append(column, `cs.${JSON.stringify(value)}`)
     }
     return this
   }
@@ -210,16 +226,19 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  containedBy(column: keyof T, value: string | T[keyof T][] | object): this {
+  containedBy<ColumnName extends string & keyof Table>(
+    column: ColumnName,
+    value: string | Table[ColumnName][] | Record<string, unknown>
+  ): this {
     if (typeof value === 'string') {
       // range
-      this.url.searchParams.append(`${column}`, `cd.${value}`)
+      this.url.searchParams.append(column, `cd.${value}`)
     } else if (Array.isArray(value)) {
       // array
-      this.url.searchParams.append(`${column}`, `cd.{${value.join(',')}}`)
+      this.url.searchParams.append(column, `cd.{${value.join(',')}}`)
     } else {
       // json
-      this.url.searchParams.append(`${column}`, `cd.${JSON.stringify(value)}`)
+      this.url.searchParams.append(column, `cd.${JSON.stringify(value)}`)
     }
     return this
   }
@@ -231,8 +250,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeLt(column: keyof T, range: string): this {
-    this.url.searchParams.append(`${column}`, `sl.${range}`)
+  rangeLt<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this {
+    this.url.searchParams.append(column, `sl.${range}`)
     return this
   }
 
@@ -243,8 +262,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeGt(column: keyof T, range: string): this {
-    this.url.searchParams.append(`${column}`, `sr.${range}`)
+  rangeGt<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this {
+    this.url.searchParams.append(column, `sr.${range}`)
     return this
   }
 
@@ -255,8 +274,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeGte(column: keyof T, range: string): this {
-    this.url.searchParams.append(`${column}`, `nxl.${range}`)
+  rangeGte<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this {
+    this.url.searchParams.append(column, `nxl.${range}`)
     return this
   }
 
@@ -267,8 +286,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeLte(column: keyof T, range: string): this {
-    this.url.searchParams.append(`${column}`, `nxr.${range}`)
+  rangeLte<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this {
+    this.url.searchParams.append(column, `nxr.${range}`)
     return this
   }
 
@@ -279,8 +298,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param range  The range to filter with.
    */
-  rangeAdjacent(column: keyof T, range: string): this {
-    this.url.searchParams.append(`${column}`, `adj.${range}`)
+  rangeAdjacent<ColumnName extends string & keyof Table>(column: ColumnName, range: string): this {
+    this.url.searchParams.append(column, `adj.${range}`)
     return this
   }
 
@@ -291,13 +310,16 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param column  The column to filter on.
    * @param value  The value to filter with.
    */
-  overlaps(column: keyof T, value: string | T[keyof T][]): this {
+  overlaps<ColumnName extends string & keyof Table>(
+    column: ColumnName,
+    value: string | Table[ColumnName][]
+  ): this {
     if (typeof value === 'string') {
       // range
-      this.url.searchParams.append(`${column}`, `ov.${value}`)
+      this.url.searchParams.append(column, `ov.${value}`)
     } else {
       // array
-      this.url.searchParams.append(`${column}`, `ov.{${value.join(',')}}`)
+      this.url.searchParams.append(column, `ov.{${value.join(',')}}`)
     }
     return this
   }
@@ -311,8 +333,8 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param config  The text search configuration to use.
    * @param type  The type of tsquery conversion to use on `query`.
    */
-  textSearch(
-    column: keyof T,
+  textSearch<ColumnName extends string & keyof Table>(
+    column: ColumnName,
     query: string,
     { config, type }: { config?: string; type?: 'plain' | 'phrase' | 'websearch' } = {}
   ): this {
@@ -325,7 +347,7 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
       typePart = 'w'
     }
     const configPart = config === undefined ? '' : `(${config})`
-    this.url.searchParams.append(`${column}`, `${typePart}fts${configPart}.${query}`)
+    this.url.searchParams.append(column, `${typePart}fts${configPart}.${query}`)
     return this
   }
 
@@ -336,8 +358,12 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param operator  The operator to filter with.
    * @param value  The value to filter with.
    */
-  filter(column: keyof T, operator: `${'' | 'not.'}${FilterOperator}`, value: any): this {
-    this.url.searchParams.append(`${column}`, `${operator}.${value}`)
+  filter<ColumnName extends string & keyof Table>(
+    column: ColumnName,
+    operator: `${'' | 'not.'}${FilterOperator}`,
+    value: any
+  ): this {
+    this.url.searchParams.append(column, `${operator}.${value}`)
     return this
   }
 
@@ -347,9 +373,11 @@ export default class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder
    * @param query  The object to filter with, with column names as keys mapped
    *               to their filter values.
    */
-  match(query: Record<string, unknown>): this {
-    Object.keys(query).forEach((key) => {
-      this.url.searchParams.append(`${key}`, `eq.${query[key]}`)
+  match<ColumnName extends string & keyof Table>(
+    query: Record<ColumnName, Table[ColumnName]>
+  ): this {
+    Object.entries(query).forEach(([column, value]) => {
+      this.url.searchParams.append(column, `eq.${value}`)
     })
     return this
   }

--- a/src/PostgrestQueryBuilder.ts
+++ b/src/PostgrestQueryBuilder.ts
@@ -41,10 +41,7 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
    */
   select<
     Query extends string = '*',
-    Result = GetResult<
-      Table['Required'] & Table['Optional'] & Table['Readonly'],
-      Query extends '*' ? '*' : Query
-    >
+    Result = GetResult<Table['Row'], Query extends '*' ? '*' : Query>
   >(
     columns?: Query,
     {
@@ -54,7 +51,7 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
       head?: boolean
       count?: 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestFilterBuilder<Table['Required'] & Table['Optional'] & Table['Readonly'], Result> {
+  ): PostgrestFilterBuilder<Table['Row'], Result> {
     const method = head ? 'HEAD' : 'GET'
     // Remove whitespaces except when quoted
     let quoted = false
@@ -92,17 +89,14 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
    * @param values  The values to insert.
    * @param count  Count algorithm to use to count rows in a table.
    */
-  insert<
-    Row extends Table['Required'] &
-      Partial<Table['Optional'] & { [_ in keyof Table['Readonly']]?: never }>
-  >(
+  insert<Row extends Table['Insert']>(
     values: Row | Row[],
     {
       count,
     }: {
       count?: 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestFilterBuilder<Table['Required'] & Table['Optional'] & Table['Readonly'], undefined> {
+  ): PostgrestFilterBuilder<Table['Row'], undefined> {
     const method = 'POST'
 
     const prefersHeaders = []
@@ -144,10 +138,7 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
    * @param options.onConflict  By specifying the `on_conflict` query parameter, you can make UPSERT work on a column(s) that has a UNIQUE constraint.
    * @param options.ignoreDuplicates  Specifies if duplicate rows should be ignored and not inserted.
    */
-  upsert<
-    Row extends Table['Required'] &
-      Partial<Table['Optional']> & { [_ in keyof Table['Readonly']]?: never }
-  >(
+  upsert<Row extends Table['Insert']>(
     values: Row | Row[],
     {
       onConflict,
@@ -158,7 +149,7 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
       count?: 'exact' | 'planned' | 'estimated'
       ignoreDuplicates?: boolean
     } = {}
-  ): PostgrestFilterBuilder<Table['Required'] & Table['Optional'] & Table['Readonly'], undefined> {
+  ): PostgrestFilterBuilder<Table['Row'], undefined> {
     const method = 'POST'
 
     const prefersHeaders = [`resolution=${ignoreDuplicates ? 'ignore' : 'merge'}-duplicates`]
@@ -191,18 +182,14 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
    * @param values  The values to update.
    * @param count  Count algorithm to use to count rows in a table.
    */
-  update<
-    Row extends Table['Readonly'] extends Record<string, unknown>
-      ? Partial<Table['Optional' | 'Required']> & { [_ in keyof Table['Readonly']]?: never }
-      : any
-  >(
+  update<Row extends Table['Update']>(
     values: Row,
     {
       count,
     }: {
       count?: 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestFilterBuilder<Table['Required'] & Table['Optional'] & Table['Readonly'], undefined> {
+  ): PostgrestFilterBuilder<Table['Row'], undefined> {
     const method = 'PATCH'
     const prefersHeaders = []
     const body = values
@@ -235,10 +222,7 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
     count,
   }: {
     count?: 'exact' | 'planned' | 'estimated'
-  } = {}): PostgrestFilterBuilder<
-    Table['Required'] & Table['Optional'] & Table['Readonly'],
-    undefined
-  > {
+  } = {}): PostgrestFilterBuilder<Table['Row'], undefined> {
     const method = 'DELETE'
     const prefersHeaders = []
     if (count) {

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -50,13 +50,21 @@ export default class PostgrestTransformBuilder<
    */
   order<ColumnName extends string & keyof Table>(
     column: ColumnName,
+    options?: { ascending?: boolean; nullsFirst?: boolean; foreignTable?: undefined }
+  ): this
+  order(
+    column: string,
+    options?: { ascending?: boolean; nullsFirst?: boolean; foreignTable: string }
+  ): this
+  order(
+    column: string,
     {
       ascending = true,
       nullsFirst = true,
       foreignTable,
     }: { ascending?: boolean; nullsFirst?: boolean; foreignTable?: string } = {}
   ): this {
-    const key = typeof foreignTable === 'undefined' ? 'order' : `${foreignTable}.order`
+    const key = foreignTable ? `${foreignTable}.order` : 'order'
     const existingOrder = this.url.searchParams.get(key)
 
     this.url.searchParams.set(

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -1,20 +1,26 @@
 import PostgrestBuilder from './PostgrestBuilder'
+import { GetResult } from './select-query-parser'
 import { PostgrestMaybeSingleResponse, PostgrestSingleResponse } from './types'
 
 /**
  * Post-filters (transforms)
  */
 
-export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
+export default class PostgrestTransformBuilder<
+  Table extends Record<string, unknown>,
+  Result
+> extends PostgrestBuilder<Result> {
   /**
    * Performs vertical filtering with SELECT.
    *
    * @param columns  The columns to retrieve, separated by commas.
    */
-  select(columns = '*'): this {
+  select<Query extends string = '*', NewResult = GetResult<Table, Query extends '*' ? '*' : Query>>(
+    columns?: Query
+  ): PostgrestTransformBuilder<Table, NewResult> {
     // Remove whitespaces except when quoted
     let quoted = false
-    const cleanedColumns = columns
+    const cleanedColumns = (columns ?? '*')
       .split('')
       .map((c) => {
         if (/\s/.test(c) && !quoted) {
@@ -31,7 +37,7 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
       this.headers['Prefer'] += ','
     }
     this.headers['Prefer'] += 'return=representation'
-    return this
+    return this as unknown as PostgrestTransformBuilder<Table, NewResult>
   }
 
   /**
@@ -42,8 +48,8 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
    * @param nullsFirst  If `true`, `null`s appear first.
    * @param foreignTable  The foreign table to use (if `column` is a foreign column).
    */
-  order(
-    column: keyof T,
+  order<ColumnName extends string & keyof Table>(
+    column: ColumnName,
     {
       ascending = true,
       nullsFirst = true,
@@ -102,9 +108,9 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
    * Retrieves only one row from the result. Result must be one row (e.g. using
    * `limit`), otherwise this will result in an error.
    */
-  single(): PromiseLike<PostgrestSingleResponse<T>> {
+  single(): PromiseLike<PostgrestSingleResponse<Result>> {
     this.headers['Accept'] = 'application/vnd.pgrst.object+json'
-    return this as PromiseLike<PostgrestSingleResponse<T>>
+    return this as PromiseLike<PostgrestSingleResponse<Result>>
   }
 
   /**
@@ -112,10 +118,10 @@ export default class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
    * (e.g. using `eq` on a UNIQUE column), otherwise this will result in an
    * error.
    */
-  maybeSingle(): PromiseLike<PostgrestMaybeSingleResponse<T>> {
+  maybeSingle(): PromiseLike<PostgrestMaybeSingleResponse<Result>> {
     this.headers['Accept'] = 'application/vnd.pgrst.object+json'
     this.allowEmpty = true
-    return this as PromiseLike<PostgrestMaybeSingleResponse<T>>
+    return this as PromiseLike<PostgrestMaybeSingleResponse<Result>>
   }
 
   /**

--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -1,0 +1,243 @@
+// Credits to @bnjmnt4n (https://www.npmjs.com/package/postgrest-query)
+
+type Whitespace = ' ' | '\n' | '\t'
+
+type LowerAlphabet =
+  | 'a'
+  | 'b'
+  | 'c'
+  | 'd'
+  | 'e'
+  | 'f'
+  | 'g'
+  | 'h'
+  | 'i'
+  | 'j'
+  | 'k'
+  | 'l'
+  | 'm'
+  | 'n'
+  | 'o'
+  | 'p'
+  | 'q'
+  | 'r'
+  | 's'
+  | 't'
+  | 'u'
+  | 'v'
+  | 'w'
+  | 'x'
+  | 'y'
+  | 'z'
+
+type Alphabet = LowerAlphabet | Uppercase<LowerAlphabet>
+
+type Digit = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '0'
+
+type Letter = Alphabet | Digit | '_'
+
+// /**
+//  * Parsed node types.
+//  * Currently only `*` and all other fields.
+//  */
+// type ParsedNode =
+//   | { star: true }
+//   | { name: string; original: string }
+//   | { name: string; foreignTable: true };
+
+/**
+ * Parser errors.
+ */
+type ParserError<Message extends string> = { error: true } & Message
+type GenericStringError = ParserError<'Received a generic string'>
+
+/**
+ * Trims whitespace from the left of the input.
+ */
+type EatWhitespace<Input extends string> = string extends Input
+  ? GenericStringError
+  : Input extends `${Whitespace}${infer Remainder}`
+  ? EatWhitespace<Remainder>
+  : Input
+
+/**
+ * Constructs a type definition for a single field of an object.
+ *
+ * @param Definitions Record of definitions, possibly generated from PostgREST's OpenAPI spec.
+ * @param Name Name of the table being queried.
+ * @param Field Single field parsed by `ParseQuery`.
+ */
+type ConstructFieldDefinition<Table extends Record<string, unknown>, Field> = Field extends {
+  star: true
+}
+  ? Table
+  : Field extends { name: string; foreignTable: true }
+  ? { [K in Field['name']]: unknown }
+  : Field extends { name: string; original: string }
+  ? { [K in Field['name']]: Table[Field['original']] }
+  : Record<string, unknown>
+
+/**
+ * Notes: all `Parse*` types assume that their input strings have their whitespace
+ * removed. They return tuples of ["Return Value", "Remainder of text"] or
+ * a `ParserError`.
+ */
+
+/**
+ * Reads a consecutive sequence of more than 1 letter,
+ * where letters are `[0-9a-zA-Z_]`.
+ */
+type ReadLetters<Input extends string> = string extends Input
+  ? GenericStringError
+  : ReadLettersHelper<Input, ''> extends [`${infer Letters}`, `${infer Remainder}`]
+  ? Letters extends ''
+    ? ParserError<`Expected letter at \`${Input}\``>
+    : [Letters, Remainder]
+  : ReadLettersHelper<Input, ''>
+
+type ReadLettersHelper<Input extends string, Acc extends string> = string extends Input
+  ? GenericStringError
+  : Input extends `${infer L}${infer Remainder}`
+  ? L extends Letter
+    ? ReadLettersHelper<Remainder, `${Acc}${L}`>
+    : [Acc, Input]
+  : [Acc, '']
+
+/**
+ * Parses an identifier.
+ * For now, identifiers are just sequences of more than 1 letter.
+ *
+ * TODO: allow for double quoted strings.
+ */
+type ParseIdentifier<Input extends string> = ReadLetters<Input>
+
+/**
+ * Parses a node.
+ * A node is one of the following:
+ * - `*`
+ * - `field`
+ * - `field(nodes)`
+ * - `renamed_field:field`
+ * - `renamed_field:field(nodes)`
+ * - `renamed_field:field!hint(nodes)`
+ *
+ * TODO: casting operators `::text`, JSON operators `->`, `->>`.
+ */
+type ParseNode<Input extends string> = Input extends ''
+  ? ParserError<'Empty string'>
+  : // `*`
+  Input extends `*${infer Remainder}`
+  ? [{ star: true }, EatWhitespace<Remainder>]
+  : ParseIdentifier<Input> extends [infer Name, `${infer Remainder}`]
+  ? EatWhitespace<Remainder> extends `:${infer Remainder}`
+    ? ParseIdentifier<EatWhitespace<Remainder>> extends [infer OriginalName, `${infer Remainder}`]
+      ? EatWhitespace<Remainder> extends `!${infer Remainder}`
+        ? ParseIdentifier<EatWhitespace<Remainder>> extends [infer _Hint, `${infer Remainder}`]
+          ? ParseEmbeddedResource<EatWhitespace<Remainder>> extends [
+              infer _Fields,
+              `${infer Remainder}`
+            ]
+            ? // `renamed_field:field!hint(nodes)`
+              [
+                {
+                  name: Name
+                  foreignTable: true
+                },
+                EatWhitespace<Remainder>
+              ]
+            : ParseEmbeddedResource<EatWhitespace<Remainder>> extends ParserError<string>
+            ? ParseEmbeddedResource<EatWhitespace<Remainder>>
+            : ParserError<'Expected embedded resource after `!hint`'>
+          : ParserError<'Expected identifier after `!`'>
+        : ParseEmbeddedResource<EatWhitespace<Remainder>> extends [
+            infer _Fields,
+            `${infer Remainder}`
+          ]
+        ? // `renamed_field:field(nodes)`
+          [{ name: Name; foreignTable: true }, EatWhitespace<Remainder>]
+        : ParseEmbeddedResource<EatWhitespace<Remainder>> extends ParserError<string>
+        ? ParseEmbeddedResource<EatWhitespace<Remainder>>
+        : // `renamed_field:field`
+          [{ name: Name; original: OriginalName }, EatWhitespace<Remainder>]
+      : ParseIdentifier<EatWhitespace<Remainder>>
+    : ParseEmbeddedResource<EatWhitespace<Remainder>> extends [infer _Fields, `${infer Remainder}`]
+    ? // `field(nodes)`
+      [{ name: Name; foreignTable: true }, EatWhitespace<Remainder>]
+    : ParseEmbeddedResource<EatWhitespace<Remainder>> extends ParserError<string>
+    ? ParseEmbeddedResource<EatWhitespace<Remainder>>
+    : // `field`
+      [{ name: Name; original: Name }, EatWhitespace<Remainder>]
+  : ParserError<`Expected identifier at \`${Input}\``>
+
+/**
+ * Parses an embedded resource, which is an opening `(`, followed by a sequence of
+ * nodes, separated by `,`, then a closing `)`.
+ *
+ * Returns a tuple of ["Parsed fields", "Remainder of text"], an error,
+ * or the original string input indicating that no opening `(` was found.
+ */
+type ParseEmbeddedResource<Input extends string> = Input extends `(${infer Remainder}`
+  ? ParseNodes<EatWhitespace<Remainder>> extends [infer Fields, `${infer Remainder}`]
+    ? EatWhitespace<Remainder> extends `)${infer Remainder}`
+      ? Fields extends []
+        ? ParserError<'Expected fields after `(`'>
+        : [Fields, EatWhitespace<Remainder>]
+      : ParserError<`Expected ")"`>
+    : ParseNodes<EatWhitespace<Remainder>>
+  : Input
+
+/**
+ * Parses a sequence of nodes, separated by `,`.
+ *
+ * Returns a tuple of ["Parsed fields", "Remainder of text"] or an error.
+ */
+type ParseNodes<Input extends string> = string extends Input
+  ? GenericStringError
+  : ParseNodesHelper<Input, []>
+
+type ParseNodesHelper<Input extends string, Fields extends unknown[]> = ParseNode<Input> extends [
+  infer Field,
+  `${infer Remainder}`
+]
+  ? EatWhitespace<Remainder> extends `,${infer Remainder}`
+    ? ParseNodesHelper<EatWhitespace<Remainder>, [Field, ...Fields]>
+    : [[Field, ...Fields], EatWhitespace<Remainder>]
+  : ParseNode<Input>
+
+/**
+ * Parses a query.
+ * A query is a sequence of nodes, separated by `,`, ensuring that there is
+ * no remaining input after all nodes have been parsed.
+ *
+ * Returns an array of parsed nodes, or an error.
+ */
+type ParseQuery<Query extends string> = string extends Query
+  ? GenericStringError
+  : ParseNodes<EatWhitespace<Query>> extends [infer Fields, `${infer Remainder}`]
+  ? EatWhitespace<Remainder> extends ''
+    ? Fields
+    : ParserError<`Unexpected input: ${Remainder}`>
+  : ParseNodes<EatWhitespace<Query>>
+
+type GetResultHelper<
+  Table extends Record<string, unknown>,
+  Fields extends unknown[],
+  Acc
+> = Fields extends [infer R]
+  ? GetResultHelper<Table, [], ConstructFieldDefinition<Table, R> & Acc>
+  : Fields extends [infer R, ...infer Rest]
+  ? GetResultHelper<Table, Rest, ConstructFieldDefinition<Table, R> & Acc>
+  : Acc
+
+/**
+ * Constructs a type definition for an object based on a given PostgREST query.
+ *
+ * @param Table Record<string, unknown>.
+ * @param Query Select query string literal to parse.
+ */
+export type GetResult<
+  Table extends Record<string, unknown>,
+  Query extends string
+> = ParseQuery<Query> extends unknown[]
+  ? GetResultHelper<Table, ParseQuery<Query>, unknown>
+  : ParseQuery<Query>

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,9 +45,9 @@ export type PostgrestSingleResponse<T> =
 export type PostgrestMaybeSingleResponse<T> = PostgrestSingleResponse<T | undefined>
 
 export type GenericTable = {
-  Required: Record<string, unknown>
-  Optional: Record<string, unknown>
-  Readonly: Record<string, unknown>
+  Row: Record<string, unknown>
+  Insert: Record<string, unknown>
+  Update: Record<string, unknown>
 }
 
 export type GenericFunction = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,3 +43,19 @@ export type PostgrestSingleResponse<T> =
   | PostgrestSingleResponseSuccess<T>
   | PostgrestResponseFailure
 export type PostgrestMaybeSingleResponse<T> = PostgrestSingleResponse<T | undefined>
+
+export type GenericTable = {
+  Required: Record<string, unknown>
+  Optional: Record<string, unknown>
+  Readonly: Record<string, unknown>
+}
+
+export type GenericFunction = {
+  Args: Record<string, unknown>
+  Returns: unknown
+}
+
+export type GenericSchema = {
+  Tables: Record<string, GenericTable>
+  Functions: Record<string, GenericFunction>
+}

--- a/test/filters.ts
+++ b/test/filters.ts
@@ -1,6 +1,7 @@
 import { PostgrestClient } from '../src/index'
+import { Database } from './types'
 
-const postgrest = new PostgrestClient('http://localhost:3000')
+const postgrest = new PostgrestClient<Database>('http://localhost:3000')
 
 test('not', async () => {
   const res = await postgrest.from('users').select('status').not('status', 'eq', 'OFFLINE')

--- a/test/resource-embedding.ts
+++ b/test/resource-embedding.ts
@@ -1,6 +1,7 @@
 import { PostgrestClient } from '../src/index'
+import { Database } from './types'
 
-const postgrest = new PostgrestClient('http://localhost:3000')
+const postgrest = new PostgrestClient<Database>('http://localhost:3000')
 
 test('embedded select', async () => {
   const res = await postgrest.from('users').select('messages(*)')
@@ -10,7 +11,10 @@ test('embedded select', async () => {
 describe('embedded filters', () => {
   // TODO: Test more filters
   test('embedded eq', async () => {
-    const res = await postgrest.from('users').select('messages(*)').eq('messages.channel_id', 1)
+    const res = await postgrest
+      .from('users')
+      .select('messages(*)')
+      .eq('messages.channel_id' as any, 1)
     expect(res).toMatchSnapshot()
   })
   test('embedded or', async () => {
@@ -36,7 +40,7 @@ describe('embedded transforms', () => {
     const res = await postgrest
       .from('users')
       .select('messages(*)')
-      .order('channel_id', { foreignTable: 'messages', ascending: false })
+      .order('channel_id' as any, { foreignTable: 'messages', ascending: false })
     expect(res).toMatchSnapshot()
   })
 
@@ -44,7 +48,7 @@ describe('embedded transforms', () => {
     const res = await postgrest
       .from('users')
       .select('messages(*)')
-      .order('channel_id', { foreignTable: 'messages', ascending: false })
+      .order('channel_id' as any, { foreignTable: 'messages', ascending: false })
       .order('username', { foreignTable: 'messages', ascending: false })
     expect(res).toMatchSnapshot()
   })

--- a/test/transforms.ts
+++ b/test/transforms.ts
@@ -1,8 +1,9 @@
 import { PostgrestClient } from '../src/index'
+import { Database } from './types'
 
 import { AbortController } from 'node-abort-controller'
 
-const postgrest = new PostgrestClient('http://localhost:3000')
+const postgrest = new PostgrestClient<Database>('http://localhost:3000')
 
 test('order', async () => {
   const res = await postgrest.from('users').select().order('username', { ascending: false })

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,85 @@
+type Json = string | number | boolean | null | { [key: string]: Json } | Json[]
+
+export interface Database {
+  public: {
+    Tables: {
+      users: {
+        Required: {
+          username: string
+        }
+        Optional: {
+          data: Json | null
+          age_range: string | null
+          status: 'ONLINE' | 'OFFLINE' | null
+          catchphrase: string | null
+        }
+        Readonly: {}
+      }
+      channels: {
+        Required: {}
+        Optional: {
+          id: number
+          data: Json | null
+          slug: string | null
+        }
+        Readonly: {}
+      }
+      messages: {
+        Required: {
+          username: string
+          channel_id: number
+        }
+        Optional: {
+          id: number
+          data: Json | null
+          message: string | null
+        }
+        Readonly: {}
+      }
+    }
+    Functions: {
+      get_status: {
+        Args: {
+          name_param: string
+        }
+        Returns: 'ONLINE' | 'OFFLINE'
+      }
+      get_username_and_status: {
+        Args: {
+          name_param: string
+        }
+        Returns: {
+          username: string
+          status: 'ONLINE' | 'OFFLINE' | null
+        }[]
+      }
+      void_func: {
+        Args: {}
+        Returns: undefined
+      }
+    }
+  }
+  personal: {
+    Tables: {
+      users: {
+        Required: {
+          username: string
+        }
+        Optional: {
+          data: Json | null
+          age_range: string | null
+          status: 'ONLINE' | 'OFFLINE' | null
+        }
+        Readonly: {}
+      }
+    }
+    Functions: {
+      get_status: {
+        Args: {
+          name_param: string
+        }
+        Returns: 'ONLINE' | 'OFFLINE' | null
+      }
+    }
+  }
+}

--- a/test/types.ts
+++ b/test/types.ts
@@ -4,37 +4,67 @@ export interface Database {
   public: {
     Tables: {
       users: {
-        Required: {
+        Row: {
           username: string
-        }
-        Optional: {
           data: Json | null
           age_range: string | null
           status: 'ONLINE' | 'OFFLINE' | null
           catchphrase: string | null
         }
-        Readonly: {}
+        Insert: {
+          username: string
+          data?: Json | null
+          age_range?: string | null
+          status?: 'ONLINE' | 'OFFLINE' | null
+          catchphrase?: string | null
+        }
+        Update: {
+          username?: string
+          data?: Json | null
+          age_range?: string | null
+          status?: 'ONLINE' | 'OFFLINE' | null
+          catchphrase?: string | null
+        }
       }
       channels: {
-        Required: {}
-        Optional: {
+        Row: {
           id: number
           data: Json | null
           slug: string | null
         }
-        Readonly: {}
+        Insert: {
+          id?: number
+          data?: Json | null
+          slug?: string | null
+        }
+        Update: {
+          id?: number
+          data?: Json | null
+          slug?: string | null
+        }
       }
       messages: {
-        Required: {
-          username: string
-          channel_id: number
-        }
-        Optional: {
+        Row: {
           id: number
           data: Json | null
           message: string | null
+          username: string
+          channel_id: number
         }
-        Readonly: {}
+        Insert: {
+          id?: number
+          data?: Json | null
+          message?: string | null
+          username: string
+          channel_id: number
+        }
+        Update: {
+          id?: number
+          data?: Json | null
+          message?: string | null
+          username?: string
+          channel_id?: number
+        }
       }
     }
     Functions: {
@@ -62,15 +92,24 @@ export interface Database {
   personal: {
     Tables: {
       users: {
-        Required: {
+        Row: {
           username: string
-        }
-        Optional: {
           data: Json | null
           age_range: string | null
           status: 'ONLINE' | 'OFFLINE' | null
         }
-        Readonly: {}
+        Insert: {
+          username: string
+          data?: Json | null
+          age_range?: string | null
+          status?: 'ONLINE' | 'OFFLINE' | null
+        }
+        Update: {
+          username?: string
+          data?: Json | null
+          age_range?: string | null
+          status?: 'ONLINE' | 'OFFLINE' | null
+        }
       }
     }
     Functions: {


### PR DESCRIPTION
BREAKING CHANGE: Rework typings.

Closes https://github.com/supabase/postgrest-js/issues/172, closes https://github.com/supabase/postgrest-js/issues/217.

The current typings DX is not great. The way users supply types is through `.from<T>()` which needs to be done on each call. What ends up happening most of the time is users would leave the `T` which defaults to `any`, because this is the path of least resistance.

Another sticking point is the `T` above also becomes the query result type, even though you can e.g. specify only certain columns.

This change intends to alleviate the above by 1) accepting type definitions at the constructor, and 2) parsing `.select()` query to infer the result type.

As an example, using the type definitions in `test/types.ts`:

https://github.com/supabase/postgrest-js/blob/92beeddcab1ca21de493d604819376315a15d6b6/test/types.ts#L1-L124

We can use it like:

```ts
import { Database } from './types'

const postgrest = new PostgrestClient<Database>('https://...')

const res = await postgrest
  .from(
    'users' // 'users' | 'channels' | 'messages'
  ).update(
    { data: 'foo' }, // {
                     //   username?: string
                     //   data?: Json | null
                     //   age_range?: string | null
                     //   status?: 'ONLINE' | 'OFFLINE' | null
                     //   catchphrase?: string | null
                     // } | { ... }[]
  ).eq(
    'data', // 'username' | 'data' | 'age_range' | 'status' | 'catchphrase'
    'foo',   // string | null
  ).select('name:username, status') // <- renames work too

const {
  data,  // {
         //   name: string  <- renamed
         //   status: string
         // }[] | undefined
  error, // PostgrestError | undefined
} = res
```

Most of the hard work in `.select()` query parsing is done by @bnjmnt4n in https://github.com/bnjmnt4n/postgrest-query. Here we're only implementing a subset of it because certain things are tricky to do properly, e.g.:
- column casting (`::`)
- json paths (`->`, `->>`)
- embedded tables in select query parsing (`members(id)`)
- embedded column types in filters (`members.id`)

Embedded tables in `.select()` is especially tricky because it requires relation cardinality information, which can be calculated using FK information in the DB. e.g. for `.from('orgs').select('members(*)')` `orgs -> members` can be 1-to-many so `members` would be an array, but for the opposite i.e. `.from('members').select('orgs(*)')` `members` would be `object | null`. Right now all embedded tables are typed as `unknown`.