### PR TITLE
feat: add rollback parameter to mutations and rpc

### DIFF
--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -71,6 +71,7 @@ export default class PostgrestClient<
    * @param options  Named parameters.
    * @param options.head  When set to true, no data will be returned.
    * @param options.count  Count algorithm to use to count rows in a table.
+   * @param rollback  Rollback the operation
    */
   rpc<
     FunctionName extends string & keyof Schema['Functions'],
@@ -81,9 +82,11 @@ export default class PostgrestClient<
     {
       head = false,
       count,
+      rollback = false,
     }: {
       head?: boolean
       count?: 'exact' | 'planned' | 'estimated'
+      rollback?: boolean
     } = {}
   ): PostgrestFilterBuilder<
     Function_['Returns'] extends any[]
@@ -107,9 +110,7 @@ export default class PostgrestClient<
     }
 
     const headers = { ...this.headers }
-    if (count) {
-      headers['Prefer'] = `count=${count}`
-    }
+    headers['Prefer'] = [count ? `count=${count}` : null, rollback ? 'tx=rollback' : null].join(',')
 
     return new PostgrestFilterBuilder({
       method,

--- a/src/PostgrestQueryBuilder.ts
+++ b/src/PostgrestQueryBuilder.ts
@@ -81,15 +81,18 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
   /**
    * Performs an INSERT into the table.
    *
-   * @param values  The values to insert.
-   * @param count  Count algorithm to use to count rows in a table.
+   * @param values    The values to insert.
+   * @param count     Count algorithm to use to count rows in a table.
+   * @param rollback  Rollback the operation
    */
   insert<Row extends Table['Insert']>(
     values: Row | Row[],
     {
       count,
+      rollback = false,
     }: {
       count?: 'exact' | 'planned' | 'estimated'
+      rollback?: boolean
     } = {}
   ): PostgrestFilterBuilder<Table['Row'], undefined> {
     const method = 'POST'
@@ -98,6 +101,9 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
     const body = values
     if (count) {
       prefersHeaders.push(`count=${count}`)
+    }
+    if (rollback) {
+      prefersHeaders.push(`tx=rollback`)
     }
     if (this.headers['Prefer']) {
       prefersHeaders.unshift(this.headers['Prefer'])
@@ -131,6 +137,7 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
    * @param options  Named parameters.
    * @param options.onConflict  By specifying the `on_conflict` query parameter, you can make UPSERT work on a column(s) that has a UNIQUE constraint.
    * @param options.ignoreDuplicates  Specifies if duplicate rows should be ignored and not inserted.
+   * @param rollback  Rollback the operation
    */
   upsert<Row extends Table['Insert']>(
     values: Row | Row[],
@@ -138,10 +145,12 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
       onConflict,
       count,
       ignoreDuplicates = false,
+      rollback = false,
     }: {
       onConflict?: string
       count?: 'exact' | 'planned' | 'estimated'
       ignoreDuplicates?: boolean
+      rollback?: boolean
     } = {}
   ): PostgrestFilterBuilder<Table['Row'], undefined> {
     const method = 'POST'
@@ -152,6 +161,9 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
     const body = values
     if (count) {
       prefersHeaders.push(`count=${count}`)
+    }
+    if (rollback) {
+      prefersHeaders.push(`tx=rollback`)
     }
     if (this.headers['Prefer']) {
       prefersHeaders.unshift(this.headers['Prefer'])
@@ -174,13 +186,16 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
    *
    * @param values  The values to update.
    * @param count  Count algorithm to use to count rows in a table.
+   * @param rollback  Rollback the operation
    */
   update<Row extends Table['Update']>(
     values: Row,
     {
       count,
+      rollback = false,
     }: {
       count?: 'exact' | 'planned' | 'estimated'
+      rollback?: boolean
     } = {}
   ): PostgrestFilterBuilder<Table['Row'], undefined> {
     const method = 'PATCH'
@@ -188,6 +203,9 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
     const body = values
     if (count) {
       prefersHeaders.push(`count=${count}`)
+    }
+    if (rollback) {
+      prefersHeaders.push(`tx=rollback`)
     }
     if (this.headers['Prefer']) {
       prefersHeaders.unshift(this.headers['Prefer'])
@@ -209,16 +227,22 @@ export default class PostgrestQueryBuilder<Table extends GenericTable> {
    * Performs a DELETE on the table.
    *
    * @param count  Count algorithm to use to count rows in a table.
+   * @param rollback  Rollback the operation
    */
   delete({
     count,
+    rollback = false,
   }: {
     count?: 'exact' | 'planned' | 'estimated'
+    rollback?: boolean
   } = {}): PostgrestFilterBuilder<Table['Row'], undefined> {
     const method = 'DELETE'
     const prefersHeaders = []
     if (count) {
       prefersHeaders.push(`count=${count}`)
+    }
+    if (rollback) {
+      prefersHeaders.push(`tx=rollback`)
     }
     if (this.headers['Prefer']) {
       prefersHeaders.unshift(this.headers['Prefer'])

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -410,3 +410,122 @@ test('select with no match', async () => {
     }
   `)
 })
+
+test('rollback insert/upsert', async () => {
+  //No row at the start
+  const res1 = await postgrest.from('users').select().eq('username', 'soedirgo')
+  expect(res1.data).toMatchInlineSnapshot(`Array []`)
+
+  //Insert the row and rollback
+  const res2 = await postgrest
+    .from('users')
+    .insert(
+      {
+        age_range: '[20,25)',
+        catchphrase: "'cat' 'fat'",
+        data: null,
+        status: 'ONLINE',
+        username: 'soedirgo',
+      },
+      { rollback: true }
+    )
+    .select()
+    .single()
+  expect(res2.data).toMatchInlineSnapshot(`
+    Object {
+      "age_range": "[20,25)",
+      "catchphrase": "'cat' 'fat'",
+      "data": null,
+      "status": "ONLINE",
+      "username": "soedirgo",
+    }
+  `)
+
+  //Upsert the row and rollback
+  const res3 = await postgrest
+    .from('users')
+    .upsert(
+      {
+        age_range: '[20,25)',
+        catchphrase: "'cat' 'fat'",
+        data: null,
+        status: 'ONLINE',
+        username: 'soedirgo',
+      },
+      { rollback: true }
+    )
+    .select()
+    .single()
+  expect(res3.data).toMatchInlineSnapshot(`
+    Object {
+      "age_range": "[20,25)",
+      "catchphrase": "'cat' 'fat'",
+      "data": null,
+      "status": "ONLINE",
+      "username": "soedirgo",
+    }
+  `)
+
+  //No row at the end
+  const res4 = await postgrest.from('users').select().eq('username', 'soedirgo')
+  expect(res4.data).toMatchInlineSnapshot(`Array []`)
+})
+
+test('rollback update/rpc', async () => {
+  const res1 = await postgrest.from('users').select('status').eq('username', 'dragarcia').single()
+  expect(res1.data).toMatchInlineSnapshot(`
+    Object {
+      "status": "ONLINE",
+    }
+  `)
+
+  const res2 = await postgrest
+    .from('users')
+    .update({ status: 'OFFLINE' }, { rollback: true })
+    .eq('username', 'dragarcia')
+    .select('status')
+    .single()
+  expect(res2.data).toMatchInlineSnapshot(`
+    Object {
+      "status": "OFFLINE",
+    }
+  `)
+
+  const res3 = await postgrest.rpc('offline_user', { name_param: 'dragarcia' }, { rollback: true })
+  expect(res3.data).toMatchInlineSnapshot(`"OFFLINE"`)
+
+  const res4 = await postgrest.from('users').select('status').eq('username', 'dragarcia').single()
+  expect(res4.data).toMatchInlineSnapshot(`
+    Object {
+      "status": "ONLINE",
+    }
+  `)
+})
+
+test('rollback delete', async () => {
+  const res1 = await postgrest.from('users').select('username').eq('username', 'dragarcia').single()
+  expect(res1.data).toMatchInlineSnapshot(`
+    Object {
+      "username": "dragarcia",
+    }
+  `)
+
+  const res2 = await postgrest
+    .from('users')
+    .delete({ rollback: true })
+    .eq('username', 'dragarcia')
+    .select('username')
+    .single()
+  expect(res2.data).toMatchInlineSnapshot(`
+    Object {
+      "username": "dragarcia",
+    }
+  `)
+
+  const res3 = await postgrest.from('users').select('username').eq('username', 'dragarcia').single()
+  expect(res3.data).toMatchInlineSnapshot(`
+    Object {
+      "username": "dragarcia",
+    }
+  `)
+})

--- a/test/db/00-schema.sql
+++ b/test/db/00-schema.sql
@@ -47,6 +47,12 @@ RETURNS TABLE(username text, status user_status) AS $$
   SELECT username, status from users WHERE username=name_param;
 $$ LANGUAGE SQL IMMUTABLE;
 
+CREATE FUNCTION public.offline_user(name_param text)
+RETURNS user_status AS $$
+  UPDATE users SET status = 'OFFLINE' WHERE username=name_param
+  RETURNING status;
+$$ LANGUAGE SQL VOLATILE;
+
 CREATE FUNCTION public.void_func()
 RETURNS void AS $$
 $$ LANGUAGE SQL;

--- a/test/db/docker-compose.yml
+++ b/test/db/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       PGRST_DB_EXTRA_SEARCH_PATH: extensions
       PGRST_DB_ANON_ROLE: postgres
       PGRST_DB_PLAN_ENABLED: 1
+      PGRST_DB_TX_END: commit-allow-override
     depends_on:
       - db
   db:

--- a/test/types.ts
+++ b/test/types.ts
@@ -110,6 +110,10 @@ export interface Database {
         Args: Record<PropertyKey, never>
         Returns: undefined
       }
+      offline_user: {
+        Args: { name_param: string }
+        Returns: 'ONLINE' | 'OFFLINE'
+      }
     }
   }
 }


### PR DESCRIPTION
Rollback was added back in https://github.com/supabase/postgrest-js/pull/244 but it's a global parameter. This PR adds a rollback that can be enabled per request - for mutations and rpc(`select` is possible but not useful, so it's not included).

rollback is needed for EXPLAIN ANALYZE(since it executes the query):

```js
const res = await postgrest
    .from('users')
    .delete({rollback: true})
    .explain({analyze: true})
```