### PR TITLE
feat: add text format to explain()

### DIFF
--- a/src/PostgrestBuilder.ts
+++ b/src/PostgrestBuilder.ts
@@ -87,6 +87,11 @@ export default abstract class PostgrestBuilder<Result>
             // discard `text`
           } else if (this.headers['Accept'] === 'text/csv') {
             data = text
+          } else if (
+            this.headers['Accept'] &&
+            this.headers['Accept'].indexOf('application/vnd.pgrst.plan+text') !== -1
+          ) {
+            data = text
           } else {
             data = JSON.parse(text)
           }

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -156,6 +156,7 @@ export default class PostgrestTransformBuilder<
    * @param settings  If `true`, include information on configuration parameters that affect query planning.
    * @param buffers  If `true`, include information on buffer usage.
    * @param wal     If `true`, include information on WAL record generation
+   * @param format  The format of the output, can be 'json'(default) or 'text'
    */
   explain({
     analyze = false,
@@ -163,13 +164,17 @@ export default class PostgrestTransformBuilder<
     settings = false,
     buffers = false,
     wal = false,
+    format = 'json',
   }: {
     analyze?: boolean
     verbose?: boolean
     settings?: boolean
     buffers?: boolean
     wal?: boolean
-  } = {}): PromiseLike<PostgrestResponse<Record<string, unknown>>> {
+    format?: 'json' | 'text'
+  } = {}):
+    | PromiseLike<PostgrestResponse<Record<string, unknown>>>
+    | PromiseLike<PostgrestSingleResponse<string>> {
     const options = [
       analyze ? 'analyze' : null,
       verbose ? 'verbose' : null,
@@ -183,7 +188,8 @@ export default class PostgrestTransformBuilder<
     const forMediatype = this.headers['Accept']
     this.headers[
       'Accept'
-    ] = `application/vnd.pgrst.plan+json; for="${forMediatype}"; options=${options};`
-    return this as PromiseLike<PostgrestResponse<Record<string, unknown>>>
+    ] = `application/vnd.pgrst.plan+${format}; for="${forMediatype}"; options=${options};`
+    if (format == 'json') return this as PromiseLike<PostgrestResponse<Record<string, unknown>>>
+    else return this as PromiseLike<PostgrestSingleResponse<string>>
   }
 }

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -189,7 +189,7 @@ export default class PostgrestTransformBuilder<
     this.headers[
       'Accept'
     ] = `application/vnd.pgrst.plan+${format}; for="${forMediatype}"; options=${options};`
-    if (format == 'json') return this as PromiseLike<PostgrestResponse<Record<string, unknown>>>
+    if (format === 'json') return this as PromiseLike<PostgrestResponse<Record<string, unknown>>>
     else return this as PromiseLike<PostgrestSingleResponse<string>>
   }
 }

--- a/test/transforms.ts
+++ b/test/transforms.ts
@@ -102,9 +102,9 @@ test('abort signal', async () => {
 //   expect(res).toMatchInlineSnapshot()
 // })
 
-test('explain', async () => {
-  const res = await postgrest.from('users').select().explain()
-  expect(res).toMatchInlineSnapshot(`
+test('explain with json/text format', async () => {
+  const res1 = await postgrest.from('users').select().explain()
+  expect(res1).toMatchInlineSnapshot(`
     Object {
       "count": undefined,
       "data": Array [
@@ -141,6 +141,13 @@ test('explain', async () => {
       "statusText": "OK",
     }
   `)
+
+  const res2 = await postgrest.from('users').select().explain({ format: 'text' })
+  expect(res2.data).toMatch(
+    `Aggregate  (cost=17.65..17.68 rows=1 width=112)
+  ->  Seq Scan on users  (cost=0.00..15.10 rows=510 width=132)
+`
+  )
 })
 
 test('explain with options', async () => {


### PR DESCRIPTION
json format for explain was added in https://github.com/supabase/postgrest-js/pull/293 but it's hard to read. This PR adds a text format so it looks like:

```js
postgrest.from('users').select().explain({format: 'text'}).then(({ data, error }) => console.log(data, error))

Aggregate  (cost=17.65..17.68 rows=1 width=112)
  ->  Seq Scan on users  (cost=0.00..15.10 rows=510 width=132)
```