### PR TITLE
change explain() default format from json to text

### DIFF
--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -156,7 +156,7 @@ export default class PostgrestTransformBuilder<
    * @param settings  If `true`, include information on configuration parameters that affect query planning.
    * @param buffers  If `true`, include information on buffer usage.
    * @param wal     If `true`, include information on WAL record generation
-   * @param format  The format of the output, can be 'json'(default) or 'text'
+   * @param format  The format of the output, can be 'text'(default) or `json`
    */
   explain({
     analyze = false,
@@ -164,7 +164,7 @@ export default class PostgrestTransformBuilder<
     settings = false,
     buffers = false,
     wal = false,
-    format = 'json',
+    format = 'text',
   }: {
     analyze?: boolean
     verbose?: boolean

--- a/test/transforms.ts
+++ b/test/transforms.ts
@@ -103,7 +103,7 @@ test('abort signal', async () => {
 // })
 
 test('explain with json/text format', async () => {
-  const res1 = await postgrest.from('users').select().explain()
+  const res1 = await postgrest.from('users').select().explain({format: 'json'})
   expect(res1).toMatchInlineSnapshot(`
     Object {
       "count": undefined,
@@ -142,7 +142,7 @@ test('explain with json/text format', async () => {
     }
   `)
 
-  const res2 = await postgrest.from('users').select().explain({ format: 'text' })
+  const res2 = await postgrest.from('users').select().explain()
   expect(res2.data).toMatch(
     `Aggregate  (cost=17.65..17.68 rows=1 width=112)
   ->  Seq Scan on users  (cost=0.00..15.10 rows=510 width=132)
@@ -151,7 +151,7 @@ test('explain with json/text format', async () => {
 })
 
 test('explain with options', async () => {
-  const res = await postgrest.from('users').select().explain({ verbose: true, settings: true })
+  const res = await postgrest.from('users').select().explain({ verbose: true, settings: true, format: 'json' })
   expect(res).toMatchInlineSnapshot(`
     Object {
       "count": undefined,


### PR DESCRIPTION
EXPLAIN in text format is more readable as mentioned in https://github.com/supabase/postgrest-js/pull/301