### PR TITLE
Improve return types for `throwOnError`

### DIFF
--- a/src/PostgrestBuilder.ts
+++ b/src/PostgrestBuilder.ts
@@ -1,19 +1,22 @@
 import crossFetch from 'cross-fetch'
-import PostgrestFilterBuilder from './PostgrestFilterBuilder'
-import PostgrestQueryBuilder from './PostgrestQueryBuilder'
-import PostgrestTransformBuilder from './PostgrestTransformBuilder'
+import type PostgrestFilterBuilder from './PostgrestFilterBuilder'
+import type PostgrestQueryBuilder from './PostgrestQueryBuilder'
+import type PostgrestTransformBuilder from './PostgrestTransformBuilder'
 
 import type { Fetch, PostgrestResponse } from './types'
 
-type EnableThrowOnError<T> = T extends PostgrestBuilder<infer Result, any>
-  ? PostgrestBuilder<Result, true>
-  : T extends PostgrestFilterBuilder<infer Schema, infer Row, infer Result, any>
+type EnableThrowOnError<T> = T extends PostgrestFilterBuilder<
+  infer Schema,
+  infer Row,
+  infer Result,
+  any
+>
   ? PostgrestFilterBuilder<Schema, Row, Result, true>
+  : T extends PostgrestTransformBuilder<infer Schema, infer Row, infer Result, any>
+  ? PostgrestTransformBuilder<Schema, Row, Result, true>
   : T extends PostgrestQueryBuilder<infer Schema, infer Relation, any>
   ? PostgrestQueryBuilder<Schema, Relation, true>
-  : T extends PostgrestTransformBuilder<infer Schema, infer Row, infer Result, any>
-  ? PostgrestTransformBuilder<Schema, Row, Result, any>
-  : T
+  : any
 
 export default abstract class PostgrestBuilder<Result, ThrowOnError>
   implements PromiseLike<PostgrestResponse<Result, ThrowOnError>>
@@ -55,7 +58,7 @@ export default abstract class PostgrestBuilder<Result, ThrowOnError>
    */
   throwOnError(): EnableThrowOnError<this> {
     this.shouldThrowOnError = true
-    return this as EnableThrowOnError<this>
+    return this as any
   }
 
   then<TResult1 = PostgrestResponse<Result, ThrowOnError>, TResult2 = never>(

--- a/src/PostgrestBuilder.ts
+++ b/src/PostgrestBuilder.ts
@@ -1,9 +1,22 @@
 import crossFetch from 'cross-fetch'
+import PostgrestFilterBuilder from './PostgrestFilterBuilder'
+import PostgrestQueryBuilder from './PostgrestQueryBuilder'
+import PostgrestTransformBuilder from './PostgrestTransformBuilder'
 
 import type { Fetch, PostgrestResponse } from './types'
 
-export default abstract class PostgrestBuilder<Result>
-  implements PromiseLike<PostgrestResponse<Result>>
+type EnableThrowOnError<T> = T extends PostgrestBuilder<infer Result, any>
+  ? PostgrestBuilder<Result, true>
+  : T extends PostgrestFilterBuilder<infer Schema, infer Row, infer Result, any>
+  ? PostgrestFilterBuilder<Schema, Row, Result, true>
+  : T extends PostgrestQueryBuilder<infer Schema, infer Relation, any>
+  ? PostgrestQueryBuilder<Schema, Relation, true>
+  : T extends PostgrestTransformBuilder<infer Schema, infer Row, infer Result, any>
+  ? PostgrestTransformBuilder<Schema, Row, Result, any>
+  : T
+
+export default abstract class PostgrestBuilder<Result, ThrowOnError>
+  implements PromiseLike<PostgrestResponse<Result, ThrowOnError>>
 {
   protected method: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE'
   protected url: URL
@@ -15,7 +28,7 @@ export default abstract class PostgrestBuilder<Result>
   protected fetch: Fetch
   protected allowEmpty: boolean
 
-  constructor(builder: PostgrestBuilder<Result>) {
+  constructor(builder: PostgrestBuilder<Result, ThrowOnError>) {
     this.method = builder.method
     this.url = builder.url
     this.headers = builder.headers
@@ -40,14 +53,14 @@ export default abstract class PostgrestBuilder<Result>
    *
    * {@link https://github.com/supabase/supabase-js/issues/92}
    */
-  throwOnError(): this {
+  throwOnError(): EnableThrowOnError<this> {
     this.shouldThrowOnError = true
-    return this
+    return this as EnableThrowOnError<this>
   }
 
-  then<TResult1 = PostgrestResponse<Result>, TResult2 = never>(
+  then<TResult1 = PostgrestResponse<Result, ThrowOnError>, TResult2 = never>(
     onfulfilled?:
-      | ((value: PostgrestResponse<Result>) => TResult1 | PromiseLike<TResult1>)
+      | ((value: PostgrestResponse<Result, ThrowOnError>) => TResult1 | PromiseLike<TResult1>)
       | undefined
       | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -63,15 +63,18 @@ export default class PostgrestClient<
    */
   from<
     TableName extends string & keyof Schema['Tables'],
-    Table extends Schema['Tables'][TableName]
-  >(relation: TableName): PostgrestQueryBuilder<Schema, Table>
-  from<ViewName extends string & keyof Schema['Views'], View extends Schema['Views'][ViewName]>(
-    relation: ViewName
-  ): PostgrestQueryBuilder<Schema, View>
-  from(relation: string): PostgrestQueryBuilder<Schema, any>
-  from(relation: string): PostgrestQueryBuilder<Schema, any> {
+    Table extends Schema['Tables'][TableName],
+    ThrowOnError
+  >(relation: TableName): PostgrestQueryBuilder<Schema, Table, ThrowOnError>
+  from<
+    ViewName extends string & keyof Schema['Views'],
+    View extends Schema['Views'][ViewName],
+    ThrowOnError
+  >(relation: ViewName): PostgrestQueryBuilder<Schema, View, ThrowOnError>
+  from(relation: string): PostgrestQueryBuilder<Schema, any, false>
+  from(relation: string): PostgrestQueryBuilder<Schema, any, false> {
     const url = new URL(`${this.url}/${relation}`)
-    return new PostgrestQueryBuilder<Schema, any>(url, {
+    return new PostgrestQueryBuilder<Schema, any, false>(url, {
       headers: { ...this.headers },
       schema: this.schema,
       fetch: this.fetch,
@@ -101,7 +104,8 @@ export default class PostgrestClient<
    */
   rpc<
     FunctionName extends string & keyof Schema['Functions'],
-    Function_ extends Schema['Functions'][FunctionName]
+    Function_ extends Schema['Functions'][FunctionName],
+    ThrowOnError
   >(
     fn: FunctionName,
     args: Function_['Args'] = {},
@@ -119,7 +123,8 @@ export default class PostgrestClient<
         ? Function_['Returns'][number]
         : never
       : never,
-    Function_['Returns']
+    Function_['Returns'],
+    ThrowOnError
   > {
     let method: 'HEAD' | 'POST'
     const url = new URL(`${this.url}/rpc/${fn}`)
@@ -147,6 +152,6 @@ export default class PostgrestClient<
       body,
       fetch: this.fetch,
       allowEmpty: false,
-    } as unknown as PostgrestBuilder<Function_['Returns']>)
+    } as unknown as PostgrestBuilder<Function_['Returns'], ThrowOnError>)
   }
 }

--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -28,8 +28,9 @@ type FilterOperator =
 export default class PostgrestFilterBuilder<
   Schema extends GenericSchema,
   Row extends Record<string, unknown>,
-  Result
-> extends PostgrestTransformBuilder<Schema, Row, Result> {
+  Result,
+  ThrowOnError
+> extends PostgrestTransformBuilder<Schema, Row, Result, ThrowOnError> {
   /**
    * Match only rows where `column` is equal to `value`.
    *

--- a/src/PostgrestQueryBuilder.ts
+++ b/src/PostgrestQueryBuilder.ts
@@ -5,7 +5,8 @@ import { Fetch, GenericSchema, GenericTable, GenericView } from './types'
 
 export default class PostgrestQueryBuilder<
   Schema extends GenericSchema,
-  Relation extends GenericTable | GenericView
+  Relation extends GenericTable | GenericView,
+  ThrowOnError
 > {
   url: URL
   headers: Record<string, string>
@@ -52,10 +53,7 @@ export default class PostgrestQueryBuilder<
    * `"estimated"`: Uses exact count for low numbers and planned count for high
    * numbers.
    */
-  select<
-    Query extends string = '*',
-    Result = GetResult<Schema, Relation['Row'], Query>
-  >(
+  select<Query extends string = '*', Result = GetResult<Schema, Relation['Row'], Query>>(
     columns?: Query,
     {
       head = false,
@@ -64,7 +62,7 @@ export default class PostgrestQueryBuilder<
       head?: boolean
       count?: 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestFilterBuilder<Schema, Relation['Row'], Result> {
+  ): PostgrestFilterBuilder<Schema, Relation['Row'], Result, ThrowOnError> {
     const method = head ? 'HEAD' : 'GET'
     // Remove whitespaces except when quoted
     let quoted = false
@@ -92,7 +90,7 @@ export default class PostgrestQueryBuilder<
       schema: this.schema,
       fetch: this.fetch,
       allowEmpty: false,
-    } as unknown as PostgrestBuilder<Result>)
+    } as unknown as PostgrestBuilder<Result, ThrowOnError>)
   }
 
   /**
@@ -124,7 +122,7 @@ export default class PostgrestQueryBuilder<
     }: {
       count?: 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestFilterBuilder<Schema, Relation['Row'], undefined> {
+  ): PostgrestFilterBuilder<Schema, Relation['Row'], undefined, ThrowOnError> {
     const method = 'POST'
 
     const prefersHeaders = []
@@ -153,7 +151,7 @@ export default class PostgrestQueryBuilder<
       body,
       fetch: this.fetch,
       allowEmpty: false,
-    } as unknown as PostgrestBuilder<undefined>)
+    } as unknown as PostgrestBuilder<undefined, ThrowOnError>)
   }
 
   /**
@@ -200,7 +198,7 @@ export default class PostgrestQueryBuilder<
       ignoreDuplicates?: boolean
       count?: 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestFilterBuilder<Schema, Relation['Row'], undefined> {
+  ): PostgrestFilterBuilder<Schema, Relation['Row'], undefined, ThrowOnError> {
     const method = 'POST'
 
     const prefersHeaders = [`resolution=${ignoreDuplicates ? 'ignore' : 'merge'}-duplicates`]
@@ -223,7 +221,7 @@ export default class PostgrestQueryBuilder<
       body,
       fetch: this.fetch,
       allowEmpty: false,
-    } as unknown as PostgrestBuilder<undefined>)
+    } as unknown as PostgrestBuilder<undefined, ThrowOnError>)
   }
 
   /**
@@ -254,7 +252,7 @@ export default class PostgrestQueryBuilder<
     }: {
       count?: 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestFilterBuilder<Schema, Relation['Row'], undefined> {
+  ): PostgrestFilterBuilder<Schema, Relation['Row'], undefined, ThrowOnError> {
     const method = 'PATCH'
     const prefersHeaders = []
     const body = values
@@ -274,7 +272,7 @@ export default class PostgrestQueryBuilder<
       body,
       fetch: this.fetch,
       allowEmpty: false,
-    } as unknown as PostgrestBuilder<undefined>)
+    } as unknown as PostgrestBuilder<undefined, ThrowOnError>)
   }
 
   /**
@@ -300,7 +298,7 @@ export default class PostgrestQueryBuilder<
     count,
   }: {
     count?: 'exact' | 'planned' | 'estimated'
-  } = {}): PostgrestFilterBuilder<Schema, Relation['Row'], undefined> {
+  } = {}): PostgrestFilterBuilder<Schema, Relation['Row'], undefined, ThrowOnError> {
     const method = 'DELETE'
     const prefersHeaders = []
     if (count) {
@@ -318,6 +316,6 @@ export default class PostgrestQueryBuilder<
       schema: this.schema,
       fetch: this.fetch,
       allowEmpty: false,
-    } as unknown as PostgrestBuilder<undefined>)
+    } as unknown as PostgrestBuilder<undefined, ThrowOnError>)
   }
 }

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -150,10 +150,10 @@ export default class PostgrestTransformBuilder<
    * Query result must be zero or one row (e.g. using `.limit(1)`), otherwise
    * this returns an error.
    */
-  maybeSingle(): PromiseLike<PostgrestMaybeSingleResponse<Result>> {
+  maybeSingle(): PromiseLike<PostgrestMaybeSingleResponse<Result, ThrowOnError>> {
     this.headers['Accept'] = 'application/vnd.pgrst.object+json'
     this.allowEmpty = true
-    return this as PromiseLike<PostgrestMaybeSingleResponse<Result>>
+    return this as unknown as PromiseLike<PostgrestMaybeSingleResponse<Result, ThrowOnError>>
   }
 
   /**

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -139,9 +139,9 @@ export default class PostgrestTransformBuilder<
    * Query result must be one row (e.g. using `.limit(1)`), otherwise this
    * returns an error.
    */
-  single(): PromiseLike<PostgrestSingleResponse<Result>> {
+  single(): PromiseLike<PostgrestSingleResponse<Result, ThrowOnError>> {
     this.headers['Accept'] = 'application/vnd.pgrst.object+json'
-    return this as PromiseLike<PostgrestSingleResponse<Result>>
+    return this as unknown as PromiseLike<PostgrestSingleResponse<Result, ThrowOnError>>
   }
 
   /**
@@ -159,17 +159,19 @@ export default class PostgrestTransformBuilder<
   /**
    * Return `data` as a string in CSV format.
    */
-  csv(): PromiseLike<PostgrestSingleResponse<string>> {
+  csv(): PromiseLike<PostgrestSingleResponse<string, ThrowOnError>> {
     this.headers['Accept'] = 'text/csv'
-    return this as PromiseLike<PostgrestSingleResponse<string>>
+    return this as unknown as PromiseLike<PostgrestSingleResponse<string, ThrowOnError>>
   }
 
   /**
    * Return `data` as an object in [GeoJSON](https://geojson.org) format.
    */
-  geojson(): PromiseLike<PostgrestSingleResponse<Record<string, unknown>>> {
+  geojson(): PromiseLike<PostgrestSingleResponse<Record<string, unknown>, ThrowOnError>> {
     this.headers['Accept'] = 'application/geo+json'
-    return this as PromiseLike<PostgrestSingleResponse<Record<string, unknown>>>
+    return this as unknown as PromiseLike<
+      PostgrestSingleResponse<Record<string, unknown>, ThrowOnError>
+    >
   }
 
   /**
@@ -209,7 +211,7 @@ export default class PostgrestTransformBuilder<
     format?: 'json' | 'text'
   } = {}):
     | PromiseLike<PostgrestResponse<Record<string, unknown>, ThrowOnError>>
-    | PromiseLike<PostgrestSingleResponse<string>> {
+    | PromiseLike<PostgrestSingleResponse<string, ThrowOnError>> {
     const options = [
       analyze ? 'analyze' : null,
       verbose ? 'verbose' : null,
@@ -226,7 +228,7 @@ export default class PostgrestTransformBuilder<
     ] = `application/vnd.pgrst.plan+${format}; for="${forMediatype}"; options=${options};`
     if (format === 'json')
       return this as PromiseLike<PostgrestResponse<Record<string, unknown>, ThrowOnError>>
-    else return this as PromiseLike<PostgrestSingleResponse<string>>
+    else return this as unknown as PromiseLike<PostgrestSingleResponse<string, ThrowOnError>>
   }
 
   /**

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -10,8 +10,9 @@ import {
 export default class PostgrestTransformBuilder<
   Schema extends GenericSchema,
   Row extends Record<string, unknown>,
-  Result
-> extends PostgrestBuilder<Result> {
+  Result,
+  ThrowOnError
+> extends PostgrestBuilder<Result, ThrowOnError> {
   /**
    * Perform a SELECT on the query result.
    *
@@ -23,7 +24,7 @@ export default class PostgrestTransformBuilder<
    */
   select<Query extends string = '*', NewResult = GetResult<Schema, Row, Query>>(
     columns?: Query
-  ): PostgrestTransformBuilder<Schema, Row, NewResult> {
+  ): PostgrestTransformBuilder<Schema, Row, NewResult, ThrowOnError> {
     // Remove whitespaces except when quoted
     let quoted = false
     const cleanedColumns = (columns ?? '*')
@@ -43,7 +44,7 @@ export default class PostgrestTransformBuilder<
       this.headers['Prefer'] += ','
     }
     this.headers['Prefer'] += 'return=representation'
-    return this as unknown as PostgrestTransformBuilder<Schema, Row, NewResult>
+    return this as unknown as PostgrestTransformBuilder<Schema, Row, NewResult, ThrowOnError>
   }
 
   /**
@@ -207,7 +208,7 @@ export default class PostgrestTransformBuilder<
     wal?: boolean
     format?: 'json' | 'text'
   } = {}):
-    | PromiseLike<PostgrestResponse<Record<string, unknown>>>
+    | PromiseLike<PostgrestResponse<Record<string, unknown>, ThrowOnError>>
     | PromiseLike<PostgrestSingleResponse<string>> {
     const options = [
       analyze ? 'analyze' : null,
@@ -223,7 +224,8 @@ export default class PostgrestTransformBuilder<
     this.headers[
       'Accept'
     ] = `application/vnd.pgrst.plan+${format}; for="${forMediatype}"; options=${options};`
-    if (format === 'json') return this as PromiseLike<PostgrestResponse<Record<string, unknown>>>
+    if (format === 'json')
+      return this as PromiseLike<PostgrestResponse<Record<string, unknown>, ThrowOnError>>
     else return this as PromiseLike<PostgrestSingleResponse<string>>
   }
 
@@ -246,7 +248,7 @@ export default class PostgrestTransformBuilder<
    *
    * @typeParam NewResult - The new result type to override with
    */
-  returns<NewResult>(): PostgrestTransformBuilder<Schema, Row, NewResult> {
-    return this as unknown as PostgrestTransformBuilder<Schema, Row, NewResult>
+  returns<NewResult>(): PostgrestTransformBuilder<Schema, Row, NewResult, ThrowOnError> {
+    return this as unknown as PostgrestTransformBuilder<Schema, Row, NewResult, ThrowOnError>
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,10 +41,10 @@ interface PostgrestSingleResponseSuccess<T> extends PostgrestResponseBase {
   data: T
   count: number | null
 }
-export type PostgrestSingleResponse<T> =
-  | PostgrestSingleResponseSuccess<T>
-  | PostgrestResponseFailure
-export type PostgrestMaybeSingleResponse<T> = PostgrestSingleResponse<T | null>
+export type PostgrestSingleResponse<T, ThrowOnError> = ThrowOnError extends true
+  ? PostgrestSingleResponseSuccess<T>
+  : PostgrestSingleResponseSuccess<T> | PostgrestResponseFailure
+export type PostgrestMaybeSingleResponse<T> = PostgrestSingleResponse<T | null, false>
 
 export type GenericTable = {
   Row: Record<string, unknown>

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,9 +32,9 @@ interface PostgrestResponseFailure extends PostgrestResponseBase {
   data: null
   count: null
 }
-export type PostgrestResponse<T, ThrowOnError> =
-  | PostgrestResponseSuccess<T>
-  | PostgrestResponseFailure
+export type PostgrestResponse<T, ThrowOnError> = ThrowOnError extends true
+  ? PostgrestResponseSuccess<T>
+  : PostgrestResponseSuccess<T> | PostgrestResponseFailure
 
 interface PostgrestSingleResponseSuccess<T> extends PostgrestResponseBase {
   error: null

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,9 @@ interface PostgrestResponseFailure extends PostgrestResponseBase {
   data: null
   count: null
 }
-export type PostgrestResponse<T> = PostgrestResponseSuccess<T> | PostgrestResponseFailure
+export type PostgrestResponse<T, ThrowOnError> =
+  | PostgrestResponseSuccess<T>
+  | PostgrestResponseFailure
 
 interface PostgrestSingleResponseSuccess<T> extends PostgrestResponseBase {
   error: null

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,10 @@ interface PostgrestSingleResponseSuccess<T> extends PostgrestResponseBase {
 export type PostgrestSingleResponse<T, ThrowOnError> = ThrowOnError extends true
   ? PostgrestSingleResponseSuccess<T>
   : PostgrestSingleResponseSuccess<T> | PostgrestResponseFailure
-export type PostgrestMaybeSingleResponse<T> = PostgrestSingleResponse<T | null, false>
+export type PostgrestMaybeSingleResponse<T, ThrowOnError> = PostgrestSingleResponse<
+  T | null,
+  ThrowOnError
+>
 
 export type GenericTable = {
   Row: Record<string, unknown>

--- a/test/transforms.ts
+++ b/test/transforms.ts
@@ -30,7 +30,7 @@ test('range', async () => {
 })
 
 test('single', async () => {
-  const res = await postgrest.from('users').select().limit(1).throwOnError().single()
+  const res = await postgrest.from('users').select().limit(1).single()
   expect(res).toMatchSnapshot()
 })
 

--- a/test/transforms.ts
+++ b/test/transforms.ts
@@ -30,7 +30,7 @@ test('range', async () => {
 })
 
 test('single', async () => {
-  const res = await postgrest.from('users').select().limit(1).single()
+  const res = await postgrest.from('users').select().limit(1).throwOnError().single()
   expect(res).toMatchSnapshot()
 })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR improves return types for `throwOnError`, which excludes `null` for failure responses in the return type. as `throwOnError` raises exceptions instead of providing a failure response.

## What is the current behavior?

Currently `throwOnError` still types the return data as `Data | null`, whereas the `null` (failure response) case is impossible to happen.

<img width="508" alt="Screenshot 2022-11-08 at 12 34 35 PM" src="https://user-images.githubusercontent.com/1313238/200475918-295edbf7-dc6e-4cb0-82b0-47ef7dad96f8.png">

![CleanShot 2022-11-08 at 12 28 45@2x](https://user-images.githubusercontent.com/1313238/200475286-1e68ce15-1f07-4095-bf27-94b47dfbcabe.png)

## What is the new behavior?

`throwOnError` just types the return data as `Data` (`null` is still kept if the data is nullable), if error happens, it throws an exception.

<img width="1165" alt="Screenshot 2022-11-08 at 12 37 19 PM" src="https://user-images.githubusercontent.com/1313238/200476234-258824ea-deff-48d3-9695-b4dec5600a6b.png">

<img width="942" alt="Screenshot 2022-11-08 at 12 37 55 PM" src="https://user-images.githubusercontent.com/1313238/200476283-3b918655-1c6f-4658-8588-73f710c481ce.png">

## Additional context

This PR addresses https://github.com/supabase/supabase-js/issues/554

### TypeScript issue

TypeScript (4.8, 4.9) complains the circular references, however the types can be correctly inferred in Visual Studio Code.

```
src/PostgrestBuilder.ts:59:19 - error TS2577: Return type annotation circularly references itself.

59   throwOnError(): EnableThrowOnError<this> {
```