### PR TITLE
Extend query parser w/basic support for `->`/`->>` JSON operators

### DIFF
--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -38,13 +38,7 @@ type Digit = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '0'
 
 type Letter = Alphabet | Digit | '_'
 
-type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json }
-  | Json[]
+type Json = string | number | boolean | null | { [key: string]: Json } | Json[]
 
 // /**
 //  * Parsed node types.
@@ -99,8 +93,8 @@ type ConstructFieldDefinition<
     }
   : Field extends { name: string; original: string }
   ? { [K in Field['name']]: Row[Field['original']] }
-  : Field extends { name: string; jsonProperty: string; type: infer T }
-  ? { [K in Field['jsonProperty']]: T }
+  : Field extends { name: string; type: infer T }
+  ? { [K in Field['name']]: T }
   : Record<string, unknown>
 
 /**
@@ -142,12 +136,13 @@ type ParseIdentifier<Input extends string> = ReadLetters<Input>
  * A node is one of the following:
  * - `*`
  * - `field`
- * - `field->json...
+ * - `field->json...`
  * - `field(nodes)`
  * - `field!hint(nodes)`
  * - `field!inner(nodes)`
  * - `field!hint!inner(nodes)`
  * - `renamed_field:field`
+ * - `renamed_field:field->json...`
  * - `renamed_field:field(nodes)`
  * - `renamed_field:field!hint(nodes)`
  * - `renamed_field:field!inner(nodes)`
@@ -237,18 +232,28 @@ type ParseNode<Input extends string> = Input extends ''
           ]
         ? // `renamed_field:field(nodes)`
           [{ name: Name; original: OriginalName; children: Fields }, EatWhitespace<Remainder>]
+        : ParseJsonAccessor<EatWhitespace<Remainder>> extends [
+            infer _PropertyName,
+            infer PropertyType,
+            `${infer Remainder}`
+          ]
+        ? // `renamed_field:field->json...`
+          [{ name: Name; type: PropertyType }, EatWhitespace<Remainder>]
         : ParseEmbeddedResource<EatWhitespace<Remainder>> extends ParserError<string>
         ? ParseEmbeddedResource<EatWhitespace<Remainder>>
         : // `renamed_field:field`
           [{ name: Name; original: OriginalName }, EatWhitespace<Remainder>]
       : ParseIdentifier<EatWhitespace<Remainder>>
-
-    : ParseJsonAccessor<EatWhitespace<Remainder>> extends [infer PropertyName, infer PropertyType, `${infer Remainder}`]
-    ? // `field->json...
-    [{ name: Name; jsonProperty: PropertyName, type: PropertyType }, EatWhitespace<Remainder>]
     : ParseEmbeddedResource<EatWhitespace<Remainder>> extends [infer Fields, `${infer Remainder}`]
     ? // `field(nodes)`
       [{ name: Name; original: Name; children: Fields }, EatWhitespace<Remainder>]
+    : ParseJsonAccessor<EatWhitespace<Remainder>> extends [
+        infer PropertyName,
+        infer PropertyType,
+        `${infer Remainder}`
+      ]
+    ? // `field->json...`
+      [{ name: PropertyName; type: PropertyType }, EatWhitespace<Remainder>]
     : ParseEmbeddedResource<EatWhitespace<Remainder>> extends ParserError<string>
     ? ParseEmbeddedResource<EatWhitespace<Remainder>>
     : // `field`
@@ -264,16 +269,19 @@ type ParseNode<Input extends string> = Input extends ''
  */
 type ParseJsonAccessor<Input extends string> = Input extends `->${infer Remainder}`
   ? Remainder extends `>${infer Remainder}`
-    ? (ParseIdentifier<Remainder> extends [infer Name, `${infer Remainder}`]
+    ? ParseIdentifier<Remainder> extends [infer Name, `${infer Remainder}`]
       ? [Name, string, EatWhitespace<Remainder>]
-      : ParserError<'Expected property name after `->>`'>)
+      : ParserError<'Expected property name after `->>`'>
     : ParseIdentifier<Remainder> extends [infer Name, `${infer Remainder}`]
-    ? ParseJsonAccessor<Remainder> extends [infer PropertyName, infer PropertyType, `${infer Remainder}`]
+    ? ParseJsonAccessor<Remainder> extends [
+        infer PropertyName,
+        infer PropertyType,
+        `${infer Remainder}`
+      ]
       ? [PropertyName, PropertyType, EatWhitespace<Remainder>]
       : [Name, Json, EatWhitespace<Remainder>]
     : ParserError<'Expected property name after `->`'>
   : Input
-
 
 /**
  * Parses an embedded resource, which is an opening `(`, followed by a sequence of

--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -263,7 +263,7 @@ type ParseNode<Input extends string> = Input extends ''
  * or the original string input indicating that no opening `->` was found.
  */
 type ParseJsonAccessor<Input extends string> = Input extends `->${infer Remainder}`
-  ? EatWhitespace<Remainder> extends `>${infer Remainder}`
+  ? Remainder extends `>${infer Remainder}`
     ? (ParseIdentifier<Remainder> extends [infer Name, `${infer Remainder}`]
       ? [Name, string, EatWhitespace<Remainder>]
       : ParserError<'Expected property name after `->>`'>)

--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -48,7 +48,7 @@ type Json = string | number | boolean | null | { [key: string]: Json } | Json[]
 //   | { star: true }
 //   | { name: string; original: string }
 //   | { name: string; foreignTable: true }
-//   | { name: string; jsonProperty: string; type: T };
+//   | { name: string; type: T };
 
 /**
  * Parser errors.

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -42,3 +42,15 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
 {
   expectError(postgrest.from('updatable_view').update({ non_updatable_column: 0 }))
 }
+
+// json accessor in select query
+{
+  const { data, error } = await postgrest
+    .from('users')
+    .select('data->foo->bar, data->foo->>baz')
+    .single()
+  if (error) {
+    throw new Error(error.message)
+  }
+  expectType<{ bar: Json } & { baz: string }>(data)
+}

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectError, expectType } from 'tsd'
 import { PostgrestClient } from '../src/index'
-import { Database } from './types'
+import { Database, Json } from './types'
 
 const REST_URL = 'http://localhost:3000'
 const postgrest = new PostgrestClient<Database>(REST_URL)


### PR DESCRIPTION
Postgres supports [accessing properties in JSON and JSONB columns](https://www.postgresql.org/docs/current/functions-json.html) by using the `->` and `->>` operators. Postgrest [supports this too](https://postgrest.org/en/stable/api.html#json-columns). However, trying to use this in the Supabase `select` API makes Typescript barf:

```typescript
/* schema: users: { Row: { data: Json } } } */
const { data } = await db.from('users').select('data->username, data->>numLikes')

// inferred type of `data` is `ParserError<'Unexpected input: ->username, data->>numLikes'>[] | null`
```

This small extension to the query parser types makes simple `column->foo->bar->>baz` property chains work properly, e.g. the above query will infer a type of `{ username: Json, numLikes: string }`. 

Note that this doesn't currently work in combination with embedded fields or renaming -- the query parser types would realistically need to be refactored to accomplish that without a serious amount of cut-and-pasted code. I aimed to just hit the common case and scratch my own itch with minimal effort here.