### PR TITLE
Extend typing to make JSON expressions work with `order`

### DIFF
--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -7,6 +7,10 @@ import {
   PostgrestSingleResponse,
 } from './types'
 
+/* Extract the column name from a potential JSON accessor expression. */
+type ColumnName<T extends string> =
+  T extends `${infer TName}->${infer _TRest}` ? TName : T
+
 export default class PostgrestTransformBuilder<
   Schema extends GenericSchema,
   Row extends Record<string, unknown>,
@@ -46,13 +50,11 @@ export default class PostgrestTransformBuilder<
     return this as unknown as PostgrestTransformBuilder<Schema, Row, NewResult>
   }
 
-  order<ColumnName extends string & keyof Row>(
-    column: ColumnName,
-    options?: { ascending?: boolean; nullsFirst?: boolean; foreignTable?: undefined }
-  ): this
-  order(
-    column: string,
-    options?: { ascending?: boolean; nullsFirst?: boolean; foreignTable: string }
+  order<ColExpr extends string, ColName = ColumnName<ColExpr>>(
+    column: ColExpr,
+    options?: ColName extends keyof Row ?
+      { ascending?: boolean; nullsFirst?: boolean; foreignTable?: string } :
+      { ascending?: boolean; nullsFirst?: boolean; foreignTable: string }
   ): this
   /**
    * Order the query result by `column`.


### PR DESCRIPTION
Previously, if you wrote a query like this:

```typescript
// presumes a table foos that has a JSONB `data` column
const { data, error } = await client.from('foos').select('id').order('data->>count', { ascending: true })
```

It would fail to typecheck, because the typing for `order` thought that if the first parameter isn't a column name from the `foos` table in the schema, then it must be a foreign table reference, so the `foreignTable` property in the options must be specified.

Now, Typescript can extract the column name from the `data->>count` expression, and check that against the schema.

I think there are other expressions you can use here (the Postgrest [docs](https://postgrest.org/en/stable/api.html#ordering) mention computed columns) but this covers the JSON accessor case. (We could also probably use similar code in the filter builder to get better typechecking when using JSON accessors in a variety of methods.)