### PR TITLE
Target ES2017 in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "CommonJS",
     "outDir": "dist/main",
     "sourceMap": true,
-    "target": "ES2015",
+    "target": "ES2017",
 
     "strict": true,
 


### PR DESCRIPTION
I noticed that my Typescript was complaining because code in `PostgrestFilterBuilder` uses `Object.entries`, which is an ES2017 method, but Typescript was only targeting ES2015.

AFAIK ES2017 is supported by all modern browsers, so I suggest just bumping the target. You can see here for some compatibility tables: https://kangax.github.io/compat-table/es2016plus/

If you really like targeting ES2015 for a reason I don't know, you could leave the target alone and use the `lib` property to express that you expect ES2017 library functions to exist: https://www.typescriptlang.org/tsconfig#lib