### PR TITLE
Export PostgrestResponseSuccess and PostgrestResponseFailure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export { default as PostgrestTransformBuilder } from './PostgrestTransformBuilde
 export { default as PostgrestBuilder } from './PostgrestBuilder'
 export {
   PostgrestResponse,
+  PostgrestResponseFailure,
+  PostgrestResponseSuccess,
   PostgrestSingleResponse,
   PostgrestMaybeSingleResponse,
   PostgrestError,

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,12 +21,12 @@ interface PostgrestResponseBase {
   status: number
   statusText: string
 }
-interface PostgrestSingleResponseSuccess<T> extends PostgrestResponseBase {
+export interface PostgrestResponseSuccess<T> extends PostgrestResponseBase {
   error: null
   data: T
   count: number | null
 }
-interface PostgrestResponseFailure extends PostgrestResponseBase {
+export interface PostgrestResponseFailure extends PostgrestResponseBase {
   error: PostgrestError
   data: null
   count: null
@@ -36,7 +36,7 @@ interface PostgrestResponseFailure extends PostgrestResponseBase {
 // - remove PostgrestResponse and PostgrestMaybeSingleResponse
 // - rename PostgrestSingleResponse to PostgrestResponse
 export type PostgrestSingleResponse<T> =
-  | PostgrestSingleResponseSuccess<T>
+  | PostgrestResponseSuccess<T>
   | PostgrestResponseFailure
 export type PostgrestMaybeSingleResponse<T> = PostgrestSingleResponse<T | null>
 export type PostgrestResponse<T> = PostgrestSingleResponse<T[]>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Type change. Discussion here: https://github.com/supabase/supabase/discussions/12228

## What is the current behavior?

Only the top-level `PostgrestResponse` types are exported.

## What is the new behavior?

Export the sub-types that go into `PostgrestResponse` for type-union/guard-clause purposes.

## Additional context

I noticed the plan is to rename `PostgrestSingleResponse` and deprecate the current `PostgrestResponse`, so instead of exporting `PostgrestSingleResponseSuccess` under its current name I went with `PostgrestResponseSuccess`.

This _might_ mean holding the change back until v3, but since its to a (formely) internal type we should be okay.
