### PR TITLE
Explain renaming of returned columns

### DIFF
--- a/src/PostgrestQueryBuilder.ts
+++ b/src/PostgrestQueryBuilder.ts
@@ -34,7 +34,7 @@ export default class PostgrestQueryBuilder<
   /**
    * Perform a SELECT query on the table or view.
    *
-   * @param columns - The columns to retrieve, separated by commas
+   * @param columns - The columns to retrieve, separated by commas. Map a column to a custom key by writing `key:column`
    *
    * @param options - Named parameters
    *

--- a/src/PostgrestQueryBuilder.ts
+++ b/src/PostgrestQueryBuilder.ts
@@ -34,7 +34,7 @@ export default class PostgrestQueryBuilder<
   /**
    * Perform a SELECT query on the table or view.
    *
-   * @param columns - The columns to retrieve, separated by commas. Map a column to a custom key by writing `key:column`
+   * @param columns - The columns to retrieve, separated by commas. Columns can be renamed when returned with `customName:columnName`
    *
    * @param options - Named parameters
    *


### PR DESCRIPTION
I could not find a note about it in the docs so far