### PR TITLE
Prettify intersected types when selecting multiple columns

### DIFF
--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -1,6 +1,6 @@
 // Credits to @bnjmnt4n (https://www.npmjs.com/package/postgrest-query)
 
-import { GenericSchema } from './types'
+import { GenericSchema, Prettify } from './types'
 
 type Whitespace = ' ' | '\n' | '\t'
 
@@ -342,7 +342,7 @@ type GetResultHelper<
   ? GetResultHelper<Schema, Row, [], ConstructFieldDefinition<Schema, Row, R> & Acc>
   : Fields extends [infer R, ...infer Rest]
   ? GetResultHelper<Schema, Row, Rest, ConstructFieldDefinition<Schema, Row, R> & Acc>
-  : Acc
+  : Prettify<Acc>
 
 /**
  * Constructs a type definition for an object based on a given PostgREST query.

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,3 +69,6 @@ export type GenericSchema = {
   Views: Record<string, GenericView>
   Functions: Record<string, GenericFunction>
 }
+
+// https://twitter.com/mattpocockuk/status/1622730173446557697
+export type Prettify<T> = { [K in keyof T]: T[K] } & {}

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -52,7 +52,7 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   if (error) {
     throw new Error(error.message)
   }
-  expectType<{ bar: Json } & { baz: string }>(data)
+  expectType<{ bar: Json, baz: string }>(data)
 }
 
 // rpc return type


### PR DESCRIPTION
Resolves #398

## What kind of change does this PR introduce?

DX improvement

## What is the current behavior?

`.select` with multiple columns returns an intersected type:

![image](https://user-images.githubusercontent.com/6831144/219642240-5f40b6e4-f5a2-4e72-9de6-ee1d41499824.png)

## What is the new behavior?

Intersected type is prettified:

![image](https://user-images.githubusercontent.com/6831144/219641657-253c7873-52b6-4c18-873b-b12513a5dde4.png)
