### PR TITLE
feat: determine relationship cardinality from types

### DIFF
--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -28,8 +28,9 @@ type FilterOperator =
 export default class PostgrestFilterBuilder<
   Schema extends GenericSchema,
   Row extends Record<string, unknown>,
-  Result
-> extends PostgrestTransformBuilder<Schema, Row, Result> {
+  Result,
+  Relationships = unknown
+> extends PostgrestTransformBuilder<Schema, Row, Result, Relationships> {
   eq<ColumnName extends string & keyof Row>(column: ColumnName, value: Row[ColumnName]): this
   eq(column: string, value: unknown): this
   /**

--- a/src/PostgrestQueryBuilder.ts
+++ b/src/PostgrestQueryBuilder.ts
@@ -5,7 +5,8 @@ import { Fetch, GenericSchema, GenericTable, GenericView } from './types'
 
 export default class PostgrestQueryBuilder<
   Schema extends GenericSchema,
-  Relation extends GenericTable | GenericView
+  Relation extends GenericTable | GenericView,
+  Relationships = Relation extends { Relationships: infer R } ? R : unknown
 > {
   url: URL
   headers: Record<string, string>
@@ -52,7 +53,10 @@ export default class PostgrestQueryBuilder<
    * `"estimated"`: Uses exact count for low numbers and planned count for high
    * numbers.
    */
-  select<Query extends string = '*', ResultOne = GetResult<Schema, Relation['Row'], Query>>(
+  select<
+    Query extends string = '*',
+    ResultOne = GetResult<Schema, Relation['Row'], Relationships, Query>
+  >(
     columns?: Query,
     {
       head = false,
@@ -61,7 +65,7 @@ export default class PostgrestQueryBuilder<
       head?: boolean
       count?: 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestFilterBuilder<Schema, Relation['Row'], ResultOne[]> {
+  ): PostgrestFilterBuilder<Schema, Relation['Row'], ResultOne[], Relationships> {
     const method = head ? 'HEAD' : 'GET'
     // Remove whitespaces except when quoted
     let quoted = false
@@ -126,7 +130,7 @@ export default class PostgrestQueryBuilder<
       count?: 'exact' | 'planned' | 'estimated'
       defaultToNull?: boolean
     } = {}
-  ): PostgrestFilterBuilder<Schema, Relation['Row'], null> {
+  ): PostgrestFilterBuilder<Schema, Relation['Row'], null, Relationships> {
     const method = 'POST'
 
     const prefersHeaders = []
@@ -211,7 +215,7 @@ export default class PostgrestQueryBuilder<
       count?: 'exact' | 'planned' | 'estimated'
       defaultToNull?: boolean
     } = {}
-  ): PostgrestFilterBuilder<Schema, Relation['Row'], null> {
+  ): PostgrestFilterBuilder<Schema, Relation['Row'], null, Relationships> {
     const method = 'POST'
 
     const prefersHeaders = [`resolution=${ignoreDuplicates ? 'ignore' : 'merge'}-duplicates`]
@@ -275,7 +279,7 @@ export default class PostgrestQueryBuilder<
     }: {
       count?: 'exact' | 'planned' | 'estimated'
     } = {}
-  ): PostgrestFilterBuilder<Schema, Relation['Row'], null> {
+  ): PostgrestFilterBuilder<Schema, Relation['Row'], null, Relationships> {
     const method = 'PATCH'
     const prefersHeaders = []
     if (this.headers['Prefer']) {
@@ -320,7 +324,7 @@ export default class PostgrestQueryBuilder<
     count,
   }: {
     count?: 'exact' | 'planned' | 'estimated'
-  } = {}): PostgrestFilterBuilder<Schema, Relation['Row'], null> {
+  } = {}): PostgrestFilterBuilder<Schema, Relation['Row'], null, Relationships> {
     const method = 'DELETE'
     const prefersHeaders = []
     if (count) {

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -5,7 +5,8 @@ import { GenericSchema } from './types'
 export default class PostgrestTransformBuilder<
   Schema extends GenericSchema,
   Row extends Record<string, unknown>,
-  Result
+  Result,
+  Relationships = unknown
 > extends PostgrestBuilder<Result> {
   /**
    * Perform a SELECT on the query result.
@@ -16,9 +17,9 @@ export default class PostgrestTransformBuilder<
    *
    * @param columns - The columns to retrieve, separated by commas
    */
-  select<Query extends string = '*', NewResultOne = GetResult<Schema, Row, Query>>(
+  select<Query extends string = '*', NewResultOne = GetResult<Schema, Row, Relationships, Query>>(
     columns?: Query
-  ): PostgrestTransformBuilder<Schema, Row, NewResultOne[]> {
+  ): PostgrestTransformBuilder<Schema, Row, NewResultOne[], Relationships> {
     // Remove whitespaces except when quoted
     let quoted = false
     const cleanedColumns = (columns ?? '*')
@@ -38,7 +39,7 @@ export default class PostgrestTransformBuilder<
       this.headers['Prefer'] += ','
     }
     this.headers['Prefer'] += 'return=representation'
-    return this as unknown as PostgrestTransformBuilder<Schema, Row, NewResultOne[]>
+    return this as unknown as PostgrestTransformBuilder<Schema, Row, NewResultOne[], Relationships>
   }
 
   order<ColumnName extends string & keyof Row>(
@@ -249,7 +250,7 @@ export default class PostgrestTransformBuilder<
    *
    * @typeParam NewResult - The new result type to override with
    */
-  returns<NewResult>(): PostgrestTransformBuilder<Schema, Row, NewResult> {
-    return this as unknown as PostgrestTransformBuilder<Schema, Row, NewResult>
+  returns<NewResult>(): PostgrestTransformBuilder<Schema, Row, NewResult, Relationships> {
+    return this as unknown as PostgrestTransformBuilder<Schema, Row, NewResult, Relationships>
   }
 }

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -63,3 +63,21 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   }
   expectType<'ONLINE' | 'OFFLINE'>(data)
 }
+
+// many-to-one relationship
+{
+  const { data: message, error } = await postgrest.from('messages').select('user:users(*)').single()
+  if (error) {
+    throw new Error(error.message)
+  }
+  expectType<Database['public']['Tables']['users']['Row'] | null>(message.user)
+}
+
+// one-to-many relationship
+{
+  const { data: user, error } = await postgrest.from('users').select('messages(*)').single()
+  if (error) {
+    throw new Error(error.message)
+  }
+  expectType<Database['public']['Tables']['messages']['Row'][]>(user.messages)
+}

--- a/test/types.ts
+++ b/test/types.ts
@@ -5,22 +5,22 @@ export interface Database {
     Tables: {
       users: {
         Row: {
-          username: string
-          data: Json | null
           age_range: unknown | null
+          data: Json | null
           status: Database['public']['Enums']['user_status'] | null
+          username: string
         }
         Insert: {
-          username: string
-          data?: Json | null
           age_range?: unknown | null
+          data?: Json | null
           status?: Database['public']['Enums']['user_status'] | null
+          username: string
         }
         Update: {
-          username?: string
-          data?: Json | null
           age_range?: unknown | null
+          data?: Json | null
           status?: Database['public']['Enums']['user_status'] | null
+          username?: string
         }
       }
     }
@@ -29,94 +29,99 @@ export interface Database {
     }
     Functions: {
       get_status: {
-        Args: { name_param: string }
+        Args: {
+          name_param: string
+        }
         Returns: Database['public']['Enums']['user_status']
       }
     }
     Enums: {
       user_status: 'ONLINE' | 'OFFLINE'
     }
+    CompositeTypes: {
+      [_ in never]: never
+    }
   }
   public: {
     Tables: {
-      shops: {
-        Row: {
-          id: number
-          address: string | null
-          shop_geom: unknown | null
-        }
-        Insert: {
-          id: number
-          address?: string | null
-          shop_geom?: unknown | null
-        }
-        Update: {
-          id?: number
-          address?: string | null
-          shop_geom?: unknown | null
-        }
-      }
-      users: {
-        Row: {
-          username: string
-          data: Json | null
-          age_range: unknown | null
-          catchphrase: unknown | null
-          status: Database['public']['Enums']['user_status'] | null
-        }
-        Insert: {
-          username: string
-          data?: Json | null
-          age_range?: unknown | null
-          catchphrase?: unknown | null
-          status?: Database['public']['Enums']['user_status'] | null
-        }
-        Update: {
-          username?: string
-          data?: Json | null
-          age_range?: unknown | null
-          catchphrase?: unknown | null
-          status?: Database['public']['Enums']['user_status'] | null
-        }
-      }
       channels: {
         Row: {
-          id: number
           data: Json | null
+          id: number
           slug: string | null
         }
         Insert: {
-          id?: number
           data?: Json | null
+          id?: number
           slug?: string | null
         }
         Update: {
-          id?: number
           data?: Json | null
+          id?: number
           slug?: string | null
         }
       }
       messages: {
         Row: {
-          id: number
+          channel_id: number
           data: Json | null
+          id: number
           message: string | null
           username: string
-          channel_id: number
         }
         Insert: {
-          id?: number
+          channel_id: number
           data?: Json | null
+          id?: number
           message?: string | null
           username: string
-          channel_id: number
         }
         Update: {
-          id?: number
+          channel_id?: number
           data?: Json | null
+          id?: number
           message?: string | null
           username?: string
-          channel_id?: number
+        }
+      }
+      shops: {
+        Row: {
+          address: string | null
+          id: number
+          shop_geom: unknown | null
+        }
+        Insert: {
+          address?: string | null
+          id: number
+          shop_geom?: unknown | null
+        }
+        Update: {
+          address?: string | null
+          id?: number
+          shop_geom?: unknown | null
+        }
+      }
+      users: {
+        Row: {
+          age_range: unknown | null
+          catchphrase: unknown | null
+          data: Json | null
+          status: Database['public']['Enums']['user_status'] | null
+          username: string
+        }
+        Insert: {
+          age_range?: unknown | null
+          catchphrase?: unknown | null
+          data?: Json | null
+          status?: Database['public']['Enums']['user_status'] | null
+          username: string
+        }
+        Update: {
+          age_range?: unknown | null
+          catchphrase?: unknown | null
+          data?: Json | null
+          status?: Database['public']['Enums']['user_status'] | null
+          username?: string
         }
       }
     }
@@ -128,30 +133,39 @@ export interface Database {
       }
       updatable_view: {
         Row: {
-          username: string | null
           non_updatable_column: number | null
+          username: string | null
         }
         Insert: {
-          username?: string | null
           non_updatable_column?: never
+          username?: string | null
         }
         Update: {
-          username?: string | null
           non_updatable_column?: never
+          username?: string | null
         }
       }
     }
     Functions: {
       get_status: {
-        Args: { name_param: string }
+        Args: {
+          name_param: string
+        }
         Returns: Database['public']['Enums']['user_status']
       }
       get_username_and_status: {
-        Args: { name_param: string }
-        Returns: Record<string, unknown>[]
+        Args: {
+          name_param: string
+        }
+        Returns: {
+          username: string
+          status: Database['public']['Enums']['user_status']
+        }[]
       }
       offline_user: {
-        Args: { name_param: string }
+        Args: {
+          name_param: string
+        }
         Returns: Database['public']['Enums']['user_status']
       }
       void_func: {
@@ -161,6 +175,9 @@ export interface Database {
     }
     Enums: {
       user_status: 'ONLINE' | 'OFFLINE'
+    }
+    CompositeTypes: {
+      [_ in never]: never
     }
   }
 }

--- a/test/types.ts
+++ b/test/types.ts
@@ -22,6 +22,7 @@ export interface Database {
           status?: Database['public']['Enums']['user_status'] | null
           username?: string
         }
+        Relationships: []
       }
     }
     Views: {
@@ -60,6 +61,7 @@ export interface Database {
           id?: number
           slug?: string | null
         }
+        Relationships: []
       }
       messages: {
         Row: {
@@ -83,6 +85,20 @@ export interface Database {
           message?: string | null
           username?: string
         }
+        Relationships: [
+          {
+            foreignKeyName: 'messages_username_fkey'
+            columns: ['username']
+            referencedRelation: 'users'
+            referencedColumns: ['username']
+          },
+          {
+            foreignKeyName: 'messages_channel_id_fkey'
+            columns: ['channel_id']
+            referencedRelation: 'channels'
+            referencedColumns: ['id']
+          }
+        ]
       }
       shops: {
         Row: {
@@ -100,6 +116,7 @@ export interface Database {
           id?: number
           shop_geom?: unknown | null
         }
+        Relationships: []
       }
       users: {
         Row: {
@@ -123,6 +140,7 @@ export interface Database {
           status?: Database['public']['Enums']['user_status'] | null
           username?: string
         }
+        Relationships: []
       }
     }
     Views: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #303 

## What is the current behavior?

Nested tables are typed as `T[] | T | null` - it's annoying to always have to use type guards for these.

## What is the new behavior?

Infer relationship cardinality (i.e. *-to-one or *-to-many) so nested tables are typed as either `T[]` or `T | null`

- [x] Pending on https://github.com/supabase/postgres-meta/pull/577