### PR TITLE
Type change for columns that do not exist in the schema

### DIFF
--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -136,7 +136,9 @@ type ConstructFieldDefinition<
         : never
     }
   : Field extends { name: string; original: string }
-  ? { [K in Field['name']]: Row[Field['original']] }
+  ? Field['original'] extends keyof Row
+    ? { [K in Field['name']]: Row[Field['original']] }
+    : never
   : Field extends { name: string; type: infer T }
   ? { [K in Field['name']]: T }
   : Record<string, unknown>

--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -55,6 +55,7 @@ type Json = string | number | boolean | null | { [key: string]: Json } | Json[]
  */
 type ParserError<Message extends string> = { error: true } & Message
 type GenericStringError = ParserError<'Received a generic string'>
+export type SelectQueryError<Message extends string> = { error: true } & Message
 
 /**
  * Trims whitespace from the left of the input.
@@ -138,7 +139,7 @@ type ConstructFieldDefinition<
   : Field extends { name: string; original: string }
   ? Field['original'] extends keyof Row
     ? { [K in Field['name']]: Row[Field['original']] }
-    : never
+    : SelectQueryError<`Referencing missing column \`${Field['original']}\``>
   : Field extends { name: string; type: infer T }
   ? { [K in Field['name']]: T }
   : Record<string, unknown>
@@ -417,21 +418,25 @@ type GetResultHelper<
   Fields extends unknown[],
   Acc
 > = Fields extends [infer R]
-  ? GetResultHelper<
-      Schema,
-      Row,
-      Relationships,
-      [],
-      ConstructFieldDefinition<Schema, Row, Relationships, R> & Acc
-    >
+  ? ConstructFieldDefinition<Schema, Row, Relationships, R> extends SelectQueryError<infer E>
+    ? SelectQueryError<E>
+    : GetResultHelper<
+        Schema,
+        Row,
+        Relationships,
+        [],
+        ConstructFieldDefinition<Schema, Row, Relationships, R> & Acc
+      >
   : Fields extends [infer R, ...infer Rest]
-  ? GetResultHelper<
-      Schema,
-      Row,
-      Relationships,
-      Rest,
-      ConstructFieldDefinition<Schema, Row, Relationships, R> & Acc
-    >
+  ? ConstructFieldDefinition<Schema, Row, Relationships, R> extends SelectQueryError<infer E>
+    ? SelectQueryError<E>
+    : GetResultHelper<
+        Schema,
+        Row,
+        Relationships,
+        Rest,
+        ConstructFieldDefinition<Schema, Row, Relationships, R> & Acc
+      >
   : Prettify<Acc>
 
 /**

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,5 +1,6 @@
 import { expectError, expectType } from 'tsd'
-import { PostgrestClient } from '../src/index'
+import { PostgrestClient, PostgrestSingleResponse } from '../src/index'
+import { SelectQueryError } from '../src/select-query-parser'
 import { Database, Json } from './types'
 
 const REST_URL = 'http://localhost:3000'
@@ -80,4 +81,10 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
     throw new Error(error.message)
   }
   expectType<Database['public']['Tables']['messages']['Row'][]>(user.messages)
+}
+
+// referencing missing column
+{
+  const res = await postgrest.from('users').select('username, dat')
+  expectType<PostgrestSingleResponse<SelectQueryError<`Referencing missing column \`dat\``>[]>>(res)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

The type for columns that do not exist in the schema, which used to be `? ` to `null`.


## What is the current behavior?

Currently, given a column that does not exist, the property can still be specified.

![image](https://github.com/supabase/postgrest-js/assets/69892552/8991d1a5-7599-4af9-a224-392626266ed0)

## What is the new behavior?
If a non-existent column is given, the user cannot specify a non-existent column in order to return null.

![image](https://github.com/supabase/postgrest-js/assets/69892552/c1f81940-7c77-44e8-ae5d-bfd86610e8e6)

This makes it easier to recognize column name problems from why they are null or from errors.

## Additional context

It may be that this should return an error type similar to `ParserError` , `GenericStringError`, etc., but I think that would greatly expand the area to be modified.
