### PR TITLE
Documentation improvements for the `range()` method

### DIFF
--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -101,7 +101,7 @@ export default class PostgrestTransformBuilder<
   }
 
   /**
-   * Limit the query result by starting at an offset (`from`) and ending at the offset `from + to`).
+   * Limit the query result by starting at an offset (`from`) and ending at the offset (`from + to`).
    * Only records within this range are returned.
    * This respects the query order and if there is no order clause the range could behave unexpectedly.
    * The `from` and `to` values are 0-based and inclusive: `range(1, 3)` will include the second, third

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -101,7 +101,11 @@ export default class PostgrestTransformBuilder<
   }
 
   /**
-   * Limit the query result by `from` and `to` inclusively.
+   * Limit the query result by starting at an offset (`from`) and ending at the offset `from + to`).
+   * Only records within this range are returned.
+   * This respects the query order and if there is no order clause the range could behave unexpectedly.
+   * The `from` and `to` values are 0-based and inclusive: `range(1, 3)` will include the second, third
+   * and fourth rows of the query.
    *
    * @param from - The starting index from which to limit the result
    * @param to - The last index to which to limit the result


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

These updates are based on feedback in the Supabase repo's issue #15222 (https://github.com/supabase/supabase/issues/15222)

The original docs state that "range" takes a starting index and ending index and returns the values between them. This implies that it's using the primary ID. But it actually works more like limit + offset.

## What is the new behavior?

I've updated the docs to explain how it works in greater detail.