### PR TITLE
Optionally set schema per PostgrestQueryBuilder

### DIFF
--- a/src/PostgrestQueryBuilder.ts
+++ b/src/PostgrestQueryBuilder.ts
@@ -32,6 +32,11 @@ export default class PostgrestQueryBuilder<
     this.fetch = fetch
   }
 
+  setSchema(schema?: string): PostgrestQueryBuilder<Schema, Relation, Relationships> {
+    this.schema = schema
+    return this
+  }
+
   /**
    * Perform a SELECT query on the table or view.
    *


### PR DESCRIPTION
## What kind of change does this PR introduce?

This introduces a new method to the PostgrestQueryBuilder file that allows the developer to specify which schema they're targeting with the table specified in `.from()`.

## What is the current behavior?

Currently, there is no way to do this. If I want to have only one instance of supabase-js, I can only set its schema once- upon creation. If, somewhere else in the code, I'd like to perform an operation on a table that's in a schema *other* than the one I specified, I'm SOL (or: I have to create a new supabase-js instance on the fly and set *its* schema, then run the query, which is ugly).

Related issues:
* https://github.com/supabase/postgrest-js/issues/280

## What is the new behavior?

```tsx
    supabase.from("test_table")
      .setSchema("test_schema") // ✨ :D
      // ^ I can now set the schema for this query.
      .select("*")
      .then(({ data, error }) => {
        console.log('test_schema.test_table data', data);
        console.log('test_schema.test_table error', error);
      });

    supabase.from("test_public_table")
      .select("*")
      // Note that it is optional, and does not affect other queries.
      .then(({ data, error }) => {
        console.log('public.test_public_table data', data);
        console.log('public.test_public_table error', error);
      });
      
```

Sample output:
![image](https://github.com/supabase/postgrest-js/assets/26691026/89e43372-5937-4ddf-ae80-ecbadb1da060)

## Additional context

Clearly, it's not just this class that needs to change. It's also the typings, and with it possibly updating the [database definition generator](https://supabase.com/docs/reference/javascript/typescript-support) to include *all* public schemas / all schemas the anon key has access to (via the project API settings, see image below). This then requires changing the way clients _accept_ database typings (or, actually *any* place a `Database` typings file is accepted, e.g. `createPages{Server,Browser}Client<Database>()`, etc.). More to come later.

Also, when I created this new schema for testing purposes, [I had to grant it access to the roles I wanted](https://supabase.com/docs/guides/integrations/prisma#missing-grants). It would be nice if this were an automated thing? Possibly even further scope creep, I'm not gonna push it too much.

![image](https://github.com/supabase/postgrest-js/assets/26691026/f24659cd-9351-45e5-9f02-4a862ac228ca)

By the way, the way that I tested this was not directly through `new PostgrestClient(URL)`, I basically `npm link`'d the HELL out of everything. My development cycle looked like:
1. Clone postgrest-js and supabase-js
2. Create a test project (next.js in this case)
3. Make the changes to `postgrest-js`, then `npm link` it so I can access this specific version of the package anywhere
4. In supabase-js, run `npm link @supabase/postgrest-js` to *override* its dependency, instead pointing to my local copy
5. In supabase-js, run `npm link` so I can access *this specific overriden* version anywhere
6. In my testing project, run `npm link @supabase/supabase-js`
7. Repeat steps 3 - 7.