### PR TITLE
Handle column name embed

### DIFF
--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -154,7 +154,7 @@ type HasUniqueFKey<FKeyName, Relationships> = InArray<
 >
 
 /**
- * Returns a boolean representing whether there is a column that references a relation
+ * Returns the relation referenced by this column name, if such relation exists
  */
 type ColumnForeignRelation<ColName, Relationships> = Relationships extends [infer R]
   ? R extends { columns: string[]; referencedRelation: string }

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -149,6 +149,30 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   expectType<Database['public']['Tables']['users']['Row'] | null>(message.user)
 }
 
+// many-to-one relationship (fkey)
+{
+  const { data: message, error } = await postgrest
+    .from('messages')
+    .select('user:users!messages_username_fkey(*)')
+    .single()
+  if (error) {
+    throw new Error(error.message)
+  }
+  expectType<Database['public']['Tables']['users']['Row'] | null>(message.user)
+}
+
+// many-to-one relationship (column name)
+{
+  const { data: message, error } = await postgrest
+    .from('messages')
+    .select('user:username(*)')
+    .single()
+  if (error) {
+    throw new Error(error.message)
+  }
+  expectType<Database['public']['Tables']['users']['Row'] | null>(message.user)
+}
+
 // one-to-many relationship
 {
   const { data: user, error } = await postgrest.from('users').select('messages(*)').single()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Handle column name as target. See column name section at https://postgrest.org/en/stable/references/api/resource_embedding.html#embedding-disambiguation

## What is the new behavior?

When a many-to-one relationship from `messages`->`users` exists in form of `user_id` foreign-key in `messages`, this change allows using the following form to type-safely embed a user:

```ts
client.from("messages").select("user:user_id(name)")
```

This was previously only possible by using a relationship name as the target or by using a foreign key name as a hint

## Additional context

fixes #450