### PR TITLE
feat: add dynamic schema to postgrest client

### DIFF
--- a/test/basic.ts
+++ b/test/basic.ts
@@ -196,6 +196,51 @@ test('switch schema', async () => {
   `)
 })
 
+test('dynamic schema', async () => {
+  const postgrest = new PostgrestClient<Database>(REST_URL)
+  const res = await postgrest.schema('personal').from('users').select()
+  expect(res).toMatchInlineSnapshot(`
+    Object {
+      "count": null,
+      "data": Array [
+        Object {
+          "age_range": "[1,2)",
+          "data": null,
+          "status": "ONLINE",
+          "username": "supabot",
+        },
+        Object {
+          "age_range": "[25,35)",
+          "data": null,
+          "status": "OFFLINE",
+          "username": "kiwicopple",
+        },
+        Object {
+          "age_range": "[25,35)",
+          "data": null,
+          "status": "ONLINE",
+          "username": "awailas",
+        },
+        Object {
+          "age_range": "[20,30)",
+          "data": null,
+          "status": "ONLINE",
+          "username": "dragarcia",
+        },
+        Object {
+          "age_range": "[20,40)",
+          "data": null,
+          "status": "ONLINE",
+          "username": "leroyjenkins",
+        },
+      ],
+      "error": null,
+      "status": 200,
+      "statusText": "OK",
+    }
+  `)
+})
+
 test('on_conflict insert', async () => {
   const res = await postgrest
     .from('users')
@@ -858,6 +903,19 @@ test('rpc with head:true, count:exact', async () => {
     Object {
       "count": 1,
       "data": null,
+      "error": null,
+      "status": 200,
+      "statusText": "OK",
+    }
+  `)
+})
+
+test('rpc with dynamic schema', async () => {
+  const res = await postgrest.schema('personal').rpc('get_status', { name_param: 'kiwicopple' })
+  expect(res).toMatchInlineSnapshot(`
+    Object {
+      "count": null,
+      "data": "OFFLINE",
       "error": null,
       "status": 200,
       "statusText": "OK",


### PR DESCRIPTION
Resolves https://github.com/supabase/postgrest-js/issues/280

## What kind of change does this PR introduce?

New feature

## What is the current behavior?

See discussion on https://github.com/supabase/postgrest-js/issues/280

The current behavior is that the `PostgrestClient` is created with a schema passed into the constructor. The class instance cannot reference tables or rpc calls for any other schemas unless a new instance is created.

```ts
// implicitly "public" schema
const postgrestPublic = new PostgrestClient<Database>(REST_URL)

// explicit specification of non-public schema
const postgrestPersonal = new PostgrestClient<Database, 'personal'>(REST_URL, { schema: 'personal' })

postgrestPublic.from('users').select() // select users from the "public" schema

postgresPersonal.from('users').select() // select users from the "personal" schema
```

## What is the new behavior?

A single class instance exposes a facade method to reference other schemas:

```ts
const postgrest = new PostgrestClient<Database>(REST_URL) // implicitly "public" schema

postgrestPublic.from('users').select(); // select users from the "public" schema

postgrestPublic.schema('personal').from('users').select(); // select users from the "personal" schema
```

Type inference for responses also work, assuming a `Database` type has been supplied:
<img width="550" alt="Screenshot 2023-08-05 at 12 09 27 PM" src="https://github.com/supabase/postgrest-js/assets/12819256/7660e4c2-4ee2-4227-a352-243d9110280e">

Table schema:
<img width="522" alt="Screenshot 2023-08-05 at 12 10 09 PM" src="https://github.com/supabase/postgrest-js/assets/12819256/dbeed886-48c1-4243-8188-443346ada191">

Compare without `.schema('personal')`:
<img width="489" alt="Screenshot 2023-08-05 at 12 13 11 PM" src="https://github.com/supabase/postgrest-js/assets/12819256/1bdcac98-e01c-49e9-a407-0cbf978cc6a8">


## Additional context

Assuming this PR is accepted, this PR https://github.com/supabase/supabase-js/pull/828 could be modified like so:

```ts
export default class SupabaseClient {
  /* snip */

  /**
   * Perform a query on a schema distinct from the default schema supplied via
   * the `options.db.schema` constructor parameter.
   *
   * The schema needs to be on the list of exposed schemas inside Supabase.
   *
   * @param schema - The name of the schema to query
   */
  schema(
    schema: string & keyof Database
  ): PostgrestClient<Database[typeof schema] extends GenericSchema ? Database[typeof schema] : any, any> {
    return this.rest.schema(schema);
  }
}
```

This would allow the following:

```ts
const supabase = createClient(supabaseURL, supabaseAnonKey);

supabase.schema('personal').from('users').select();
supabase.schema('personal').rpc('get_status', { name_param: 'kiwicopple' });
```

Add any other context or screenshots.
