### PR TITLE
Make embedded resource non-nullable if using inner join

### DIFF
--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -231,7 +231,9 @@ type ConstructFieldDefinition<
           ? Child | null
           : Relationships extends unknown[]
           ? HasFKey<Field['hint'], Relationships> extends true
-            ? Child | null
+            ? Field extends { inner: true }
+              ? Child
+              : Child | null
             : Child[]
           : Child[]
         : never
@@ -260,7 +262,9 @@ type ConstructFieldDefinition<
           ? Child | null
           : Relationships extends unknown[]
           ? HasFKeyToFRel<Field['original'], Relationships> extends true
-            ? Child | null
+            ? Field extends { inner: true }
+              ? Child
+              : Child | null
             : Child[]
           : Child[]
         : never
@@ -351,7 +355,7 @@ type ParseField<Input extends string> = Input extends ''
   ? EatWhitespace<Remainder> extends `!inner${infer Remainder}`
     ? ParseEmbeddedResource<EatWhitespace<Remainder>> extends [infer Fields, `${infer Remainder}`]
       ? // `field!inner(nodes)`
-        [{ name: Name; original: Name; children: Fields }, EatWhitespace<Remainder>]
+        [{ name: Name; original: Name; children: Fields; inner: true }, EatWhitespace<Remainder>]
       : CreateParserErrorIfRequired<
           ParseEmbeddedResource<EatWhitespace<Remainder>>,
           'Expected embedded resource after `!inner`'
@@ -364,7 +368,10 @@ type ParseField<Input extends string> = Input extends ''
             `${infer Remainder}`
           ]
           ? // `field!hint!inner(nodes)`
-            [{ name: Name; original: Name; hint: Hint; children: Fields }, EatWhitespace<Remainder>]
+            [
+              { name: Name; original: Name; hint: Hint; children: Fields; inner: true },
+              EatWhitespace<Remainder>
+            ]
           : CreateParserErrorIfRequired<
               ParseEmbeddedResource<EatWhitespace<Remainder>>,
               'Expected embedded resource after `!inner`'

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -149,6 +149,18 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   expectType<Database['public']['Tables']['users']['Row'] | null>(message.user)
 }
 
+// !inner relationship
+{
+  const { data: message, error } = await postgrest
+    .from('messages')
+    .select('user:users!inner(*)')
+    .single()
+  if (error) {
+    throw new Error(error.message)
+  }
+  expectType<Database['public']['Tables']['users']['Row']>(message.user)
+}
+
 // one-to-many relationship
 {
   const { data: user, error } = await postgrest.from('users').select('messages(*)').single()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Makes embedded many-to-one resource type non-null when using inner join

## What is the current behavior?

Inner joined resources are nullable, even though in practice they must always exist

## What is the new behavior?

Fixes inner joined embedded resource type

## Additional context

fixes #456