### PR TITLE
Enforce non-null parameter to .eq

### DIFF
--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -31,8 +31,11 @@ export default class PostgrestFilterBuilder<
   Result,
   Relationships = unknown
 > extends PostgrestTransformBuilder<Schema, Row, Result, Relationships> {
-  eq<ColumnName extends string & keyof Row>(column: ColumnName, value: Row[ColumnName]): this
-  eq(column: string, value: unknown): this
+  eq<ColumnName extends string & keyof Row>(
+    column: ColumnName,
+    value: NonNullable<Row[ColumnName]>
+  ): this
+  eq<Value extends unknown>(column: string, value: NonNullable<Value>): this
   /**
    * Match only rows where `column` is equal to `value`.
    *

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -11,6 +11,15 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   expectError(postgrest.from(42))
 }
 
+// test filters
+{
+  postgrest.from('users').select().eq('username', 'foo')
+  expectError(postgrest.from('users').select().eq('username', null))
+
+  const nullableVar = 'foo' as string | null
+  expectError(postgrest.from('users').select().eq('username', nullableVar))
+}
+
 // can override result type
 {
   const { data, error } = await postgrest


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, `.eq()` allows null inputs but crucially it won't work, as you need to use `.is()` for null comparisons.

This PR adds stronger typing to ensure that null values are not passed to `.eq()`. Instead, you'll either have to do non-null assertion or a more proper method, like `.is()` or `.eqNullable()` (#463)

Note: this is kind of a breaking change, but I think an extremely useful one and call sites where this causes errors should be fixed