### PR TITLE
fix: detection of maybeSingle

### DIFF
--- a/src/PostgrestBuilder.ts
+++ b/src/PostgrestBuilder.ts
@@ -149,7 +149,7 @@ export default abstract class PostgrestBuilder<Result>
           }
         }
 
-        if (error && this.isMaybeSingle && error?.details?.includes('Results contain 0 rows')) {
+        if (error && this.isMaybeSingle && error?.details?.includes('0 rows')) {
           error = null
           status = 200
           statusText = 'OK'


### PR DESCRIPTION
Fixes #361.

On PostgREST 11.2.0, the format of the error got changed on PostgREST/postgrest#2876 to "The result contains 0 rows".

Change the detection to "0 rows". This should be backwards compatible.