### PR TITLE
refactor: Deprecate foreignTable parameter in favor of referencedTable

### DIFF
--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -487,11 +487,24 @@ export default class PostgrestFilterBuilder<
    * It's currently not possible to do an `.or()` filter across multiple tables.
    *
    * @param filters - The filters to use, following PostgREST syntax
-   * @param foreignTable - Set this to filter on foreign tables instead of the
+   * @param referencedTable - Set this to filter on referenced tables instead of the
    * current table
    */
-  or(filters: string, { foreignTable }: { foreignTable?: string } = {}): this {
-    const key = foreignTable ? `${foreignTable}.or` : 'or'
+  or(
+    filters: string,
+    {
+      referencedTable,
+      foreignTable,
+    }: {
+      referencedTable?: string
+      /**
+       * @deprecated Use `referencedTable` instead.
+       */
+      foreignTable?: string
+    } = {}
+  ): this {
+    const _referencedTable = referencedTable ?? foreignTable
+    const key = _referencedTable ? `${_referencedTable}.or` : 'or'
     this.url.searchParams.append(key, `(${filters})`)
     return this
   }

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -44,18 +44,34 @@ export default class PostgrestTransformBuilder<
 
   order<ColumnName extends string & keyof Row>(
     column: ColumnName,
-    options?: { ascending?: boolean; nullsFirst?: boolean; foreignTable?: undefined }
+    options?: {
+      ascending?: boolean
+      nullsFirst?: boolean
+      referencedTable?: undefined
+      /**
+       * @deprecated Use `referencedTable` instead.
+       */
+      foreignTable?: undefined
+    }
   ): this
   order(
     column: string,
-    options?: { ascending?: boolean; nullsFirst?: boolean; foreignTable?: string }
+    options?: {
+      ascending?: boolean
+      nullsFirst?: boolean
+      referencedTable?: string
+      /**
+       * @deprecated Use `referencedTable` instead.
+       */
+      foreignTable?: string
+    }
   ): this
   /**
    * Order the query result by `column`.
    *
    * You can call this method multiple times to order by multiple columns.
    *
-   * You can order foreign tables, but it doesn't affect the ordering of the
+   * You can order referenced tables, but it doesn't affect the ordering of the
    * current table.
    *
    * @param column - The column to order by
@@ -63,7 +79,7 @@ export default class PostgrestTransformBuilder<
    * @param options.ascending - If `true`, the result will be in ascending order
    * @param options.nullsFirst - If `true`, `null`s appear first. If `false`,
    * `null`s appear last.
-   * @param options.foreignTable - Set this to order a foreign table by foreign
+   * @param options.referencedTable - Set this to order a referenced table by their
    * columns
    */
   order(
@@ -71,10 +87,20 @@ export default class PostgrestTransformBuilder<
     {
       ascending = true,
       nullsFirst,
+      referencedTable,
       foreignTable,
-    }: { ascending?: boolean; nullsFirst?: boolean; foreignTable?: string } = {}
+    }: {
+      ascending?: boolean
+      nullsFirst?: boolean
+      referencedTable?: string
+      /**
+       * @deprecated Use `referencedTable` instead.
+       */
+      foreignTable?: string
+    } = {}
   ): this {
-    const key = foreignTable ? `${foreignTable}.order` : 'order'
+    const _referencedTable = referencedTable ?? foreignTable
+    const key = _referencedTable ? `${_referencedTable}.order` : 'order'
     const existingOrder = this.url.searchParams.get(key)
 
     this.url.searchParams.set(
@@ -91,11 +117,24 @@ export default class PostgrestTransformBuilder<
    *
    * @param count - The maximum number of rows to return
    * @param options - Named parameters
-   * @param options.foreignTable - Set this to limit rows of foreign tables
+   * @param options.referencedTable - Set this to limit rows of referenced tables
    * instead of the current table
    */
-  limit(count: number, { foreignTable }: { foreignTable?: string } = {}): this {
-    const key = typeof foreignTable === 'undefined' ? 'limit' : `${foreignTable}.limit`
+  limit(
+    count: number,
+    {
+      referencedTable,
+      foreignTable,
+    }: {
+      referencedTable?: string
+      /**
+       * @deprecated Use `referencedTable` instead.
+       */
+      foreignTable?: string
+    } = {}
+  ): this {
+    const _referencedTable = referencedTable ?? foreignTable
+    const key = typeof _referencedTable === 'undefined' ? 'limit' : `${_referencedTable}.limit`
     this.url.searchParams.set(key, `${count}`)
     return this
   }
@@ -110,12 +149,27 @@ export default class PostgrestTransformBuilder<
    * @param from - The starting index from which to limit the result
    * @param to - The last index to which to limit the result
    * @param options - Named parameters
-   * @param options.foreignTable - Set this to limit rows of foreign tables
+   * @param options.referencedTable - Set this to limit rows of referenced tables
    * instead of the current table
    */
-  range(from: number, to: number, { foreignTable }: { foreignTable?: string } = {}): this {
-    const keyOffset = typeof foreignTable === 'undefined' ? 'offset' : `${foreignTable}.offset`
-    const keyLimit = typeof foreignTable === 'undefined' ? 'limit' : `${foreignTable}.limit`
+  range(
+    from: number,
+    to: number,
+    {
+      referencedTable,
+      foreignTable,
+    }: {
+      referencedTable?: string
+      /**
+       * @deprecated Use `referencedTable` instead.
+       */
+      foreignTable?: string
+    } = {}
+  ): this {
+    const _referencedTable = referencedTable ?? foreignTable
+    const keyOffset =
+      typeof _referencedTable === 'undefined' ? 'offset' : `${_referencedTable}.offset`
+    const keyLimit = typeof _referencedTable === 'undefined' ? 'limit' : `${_referencedTable}.limit`
     this.url.searchParams.set(keyOffset, `${from}`)
     // Range is inclusive, so add 1
     this.url.searchParams.set(keyLimit, `${to - from + 1}`)

--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -47,7 +47,7 @@ type Json = string | number | boolean | null | { [key: string]: Json } | Json[]
 // type ParsedNode =
 //   | { star: true }
 //   | { name: string; original: string }
-//   | { name: string; foreignTable: true }
+//   | { name: string; referencedTable: true }
 //   | { name: string; type: T };
 
 /**

--- a/test/resource-embedding.ts
+++ b/test/resource-embedding.ts
@@ -82,11 +82,54 @@ describe('embedded filters', () => {
       }
     `)
   })
-  test('embedded or', async () => {
+  test('embedded or with deprecated foreignTable parameter', async () => {
     const res = await postgrest
       .from('users')
       .select('messages(*)')
       .or('channel_id.eq.2,message.eq.Hello World 👋', { foreignTable: 'messages' })
+    expect(res).toMatchInlineSnapshot(`
+      Object {
+        "count": null,
+        "data": Array [
+          Object {
+            "messages": Array [
+              Object {
+                "channel_id": 1,
+                "data": null,
+                "id": 1,
+                "message": "Hello World 👋",
+                "username": "supabot",
+              },
+              Object {
+                "channel_id": 2,
+                "data": null,
+                "id": 2,
+                "message": "Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.",
+                "username": "supabot",
+              },
+            ],
+          },
+          Object {
+            "messages": Array [],
+          },
+          Object {
+            "messages": Array [],
+          },
+          Object {
+            "messages": Array [],
+          },
+        ],
+        "error": null,
+        "status": 200,
+        "statusText": "OK",
+      }
+    `)
+  })
+  test('embedded or', async () => {
+    const res = await postgrest
+      .from('users')
+      .select('messages(*)')
+      .or('channel_id.eq.2,message.eq.Hello World 👋', { referencedTable: 'messages' })
     expect(res).toMatchInlineSnapshot(`
       Object {
         "count": null,
@@ -130,7 +173,7 @@ describe('embedded filters', () => {
       .from('users')
       .select('messages(*)')
       .or('channel_id.eq.2,and(message.eq.Hello World 👋,username.eq.supabot)', {
-        foreignTable: 'messages',
+        referencedTable: 'messages',
       })
     expect(res).toMatchInlineSnapshot(`
       Object {
@@ -177,7 +220,7 @@ describe('embedded transforms', () => {
     const res = await postgrest
       .from('users')
       .select('messages(*)')
-      .order('channel_id' as any, { foreignTable: 'messages', ascending: false })
+      .order('channel_id' as any, { referencedTable: 'messages', ascending: false })
     expect(res).toMatchInlineSnapshot(`
       Object {
         "count": null,
@@ -221,8 +264,8 @@ describe('embedded transforms', () => {
     const res = await postgrest
       .from('users')
       .select('messages(*)')
-      .order('channel_id' as any, { foreignTable: 'messages', ascending: false })
-      .order('username', { foreignTable: 'messages', ascending: false })
+      .order('channel_id' as any, { referencedTable: 'messages', ascending: false })
+      .order('username', { referencedTable: 'messages', ascending: false })
     expect(res).toMatchInlineSnapshot(`
       Object {
         "count": null,
@@ -262,7 +305,7 @@ describe('embedded transforms', () => {
     `)
   })
 
-  test('embedded limit', async () => {
+  test('embedded limit with deprecated foreignTable parameter', async () => {
     const res = await postgrest
       .from('users')
       .select('messages(*)')
@@ -299,11 +342,84 @@ describe('embedded transforms', () => {
     `)
   })
 
-  test('embedded range', async () => {
+  test('embedded limit', async () => {
+    const res = await postgrest
+      .from('users')
+      .select('messages(*)')
+      .limit(1, { referencedTable: 'messages' })
+    expect(res).toMatchInlineSnapshot(`
+      Object {
+        "count": null,
+        "data": Array [
+          Object {
+            "messages": Array [
+              Object {
+                "channel_id": 1,
+                "data": null,
+                "id": 1,
+                "message": "Hello World 👋",
+                "username": "supabot",
+              },
+            ],
+          },
+          Object {
+            "messages": Array [],
+          },
+          Object {
+            "messages": Array [],
+          },
+          Object {
+            "messages": Array [],
+          },
+        ],
+        "error": null,
+        "status": 200,
+        "statusText": "OK",
+      }
+    `)
+  })
+
+  test('embedded range with deprecated foreignTable parameter', async () => {
     const res = await postgrest
       .from('users')
       .select('messages(*)')
       .range(1, 1, { foreignTable: 'messages' })
+    expect(res).toMatchInlineSnapshot(`
+      Object {
+        "count": null,
+        "data": Array [
+          Object {
+            "messages": Array [
+              Object {
+                "channel_id": 2,
+                "data": null,
+                "id": 2,
+                "message": "Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.",
+                "username": "supabot",
+              },
+            ],
+          },
+          Object {
+            "messages": Array [],
+          },
+          Object {
+            "messages": Array [],
+          },
+          Object {
+            "messages": Array [],
+          },
+        ],
+        "error": null,
+        "status": 200,
+        "statusText": "OK",
+      }
+    `)
+  })
+  test('embedded range', async () => {
+    const res = await postgrest
+      .from('users')
+      .select('messages(*)')
+      .range(1, 1, { referencedTable: 'messages' })
     expect(res).toMatchInlineSnapshot(`
       Object {
         "count": null,


### PR DESCRIPTION
## What kind of change does this PR introduce?

The term `foreignTable` might be confusing when we offer foreign data wrapper. This PR deprecates the `foreignTable` parameter in filters and modifiers in favor of `referencedTable`. 