### PR TITLE
chore: `foreignTable` -> `referencedTable`

### DIFF
--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -487,11 +487,19 @@ export default class PostgrestFilterBuilder<
    * It's currently not possible to do an `.or()` filter across multiple tables.
    *
    * @param filters - The filters to use, following PostgREST syntax
-   * @param foreignTable - Set this to filter on foreign tables instead of the
-   * current table
+   * @param options - Named parameters
+   * @param options.referencedTable - Set this to filter on referenced tables
+   * instead of the parent table
+   * @param options.foreignTable - Deprecated, use `referencedTable` instead
    */
-  or(filters: string, { foreignTable }: { foreignTable?: string } = {}): this {
-    const key = foreignTable ? `${foreignTable}.or` : 'or'
+  or(
+    filters: string,
+    {
+      foreignTable,
+      referencedTable = foreignTable,
+    }: { foreignTable?: string; referencedTable?: string } = {}
+  ): this {
+    const key = referencedTable ? `${referencedTable}.or` : 'or'
     this.url.searchParams.append(key, `(${filters})`)
     return this
   }

--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -40,16 +40,6 @@ type Letter = Alphabet | Digit | '_'
 
 type Json = string | number | boolean | null | { [key: string]: Json } | Json[]
 
-// /**
-//  * Parsed node types.
-//  * Currently only `*` and all other fields.
-//  */
-// type ParsedNode =
-//   | { star: true }
-//   | { name: string; original: string }
-//   | { name: string; foreignTable: true }
-//   | { name: string; type: T };
-
 /**
  * Parser errors.
  */


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

We use the term "foreign table" for referenced tables but [Postgres already use that term for something else](https://www.postgresql.org/docs/current/sql-createforeigntable.html).

## What is the new behavior?

Deprecate `foreignTable` and use `referencedTable` moving forward