### PR TITLE
Throw on error types

### DIFF
--- a/src/PostgrestBuilder.ts
+++ b/src/PostgrestBuilder.ts
@@ -1,9 +1,9 @@
 // @ts-ignore
 import nodeFetch from '@supabase/node-fetch'
 
-import type { Fetch, PostgrestSingleResponse } from './types'
+import type { Fetch, PostgrestResponseSuccess, PostgrestSingleResponse } from './types'
 
-export default abstract class PostgrestBuilder<Result>
+export default abstract class PostgrestBuilder<Result, ThrowOnError extends boolean = false>
   implements PromiseLike<PostgrestSingleResponse<Result>>
 {
   protected method: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE'
@@ -11,12 +11,12 @@ export default abstract class PostgrestBuilder<Result>
   protected headers: Record<string, string>
   protected schema?: string
   protected body?: unknown
-  protected shouldThrowOnError = false
+  protected shouldThrowOnError: boolean
   protected signal?: AbortSignal
   protected fetch: Fetch
   protected isMaybeSingle: boolean
 
-  constructor(builder: PostgrestBuilder<Result>) {
+  constructor(builder: PostgrestBuilder<Result, ThrowOnError>) {
     this.method = builder.method
     this.url = builder.url
     this.headers = builder.headers
@@ -35,20 +35,18 @@ export default abstract class PostgrestBuilder<Result>
     }
   }
 
-  /**
-   * If there's an error with the query, throwOnError will reject the promise by
-   * throwing the error instead of returning it as part of a successful response.
-   *
-   * {@link https://github.com/supabase/supabase-js/issues/92}
-   */
-  throwOnError(): this {
+  throwOnError(): PostgrestBuilder<Result, true> {
     this.shouldThrowOnError = true
-    return this
+    return this as PostgrestBuilder<Result, true>
   }
 
   then<TResult1 = PostgrestSingleResponse<Result>, TResult2 = never>(
     onfulfilled?:
-      | ((value: PostgrestSingleResponse<Result>) => TResult1 | PromiseLike<TResult1>)
+      | ((
+          value: ThrowOnError extends true
+            ? PostgrestResponseSuccess<Result>
+            : PostgrestSingleResponse<Result>
+        ) => TResult1 | PromiseLike<TResult1>)
       | undefined
       | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null

--- a/src/PostgrestBuilder.ts
+++ b/src/PostgrestBuilder.ts
@@ -3,7 +3,7 @@ import nodeFetch from '@supabase/node-fetch'
 
 import type { Fetch, PostgrestResponseSuccess, PostgrestSingleResponse } from './types'
 
-export default abstract class PostgrestBuilder<Result, ThrowOnError extends boolean = false>
+export default abstract class PostgrestBuilder<Result, ThrowOnError extends boolean>
   implements PromiseLike<PostgrestSingleResponse<Result>>
 {
   protected method: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE'

--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -29,8 +29,9 @@ export default class PostgrestFilterBuilder<
   Schema extends GenericSchema,
   Row extends Record<string, unknown>,
   Result,
-  Relationships = unknown
-> extends PostgrestTransformBuilder<Schema, Row, Result, Relationships> {
+  Relationships, // = unknown,
+  ThrowOnError extends boolean // = false
+> extends PostgrestTransformBuilder<Schema, Row, Result, Relationships, ThrowOnError> {
   eq<ColumnName extends string & keyof Row>(
     column: ColumnName,
     value: NonNullable<Row[ColumnName]>

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -6,8 +6,9 @@ export default class PostgrestTransformBuilder<
   Schema extends GenericSchema,
   Row extends Record<string, unknown>,
   Result,
-  Relationships = unknown
-> extends PostgrestBuilder<Result> {
+  Relationships,
+  ThrowOnError extends boolean
+> extends PostgrestBuilder<Result, ThrowOnError> {
   /**
    * Perform a SELECT on the query result.
    *
@@ -19,7 +20,7 @@ export default class PostgrestTransformBuilder<
    */
   select<Query extends string = '*', NewResultOne = GetResult<Schema, Row, Relationships, Query>>(
     columns?: Query
-  ): PostgrestTransformBuilder<Schema, Row, NewResultOne[], Relationships> {
+  ): PostgrestTransformBuilder<Schema, Row, NewResultOne[], Relationships, ThrowOnError> {
     // Remove whitespaces except when quoted
     let quoted = false
     const cleanedColumns = (columns ?? '*')
@@ -39,7 +40,13 @@ export default class PostgrestTransformBuilder<
       this.headers['Prefer'] += ','
     }
     this.headers['Prefer'] += 'return=representation'
-    return this as unknown as PostgrestTransformBuilder<Schema, Row, NewResultOne[], Relationships>
+    return this as unknown as PostgrestTransformBuilder<
+      Schema,
+      Row,
+      NewResultOne[],
+      Relationships,
+      ThrowOnError
+    >
   }
 
   order<ColumnName extends string & keyof Row>(
@@ -138,11 +145,12 @@ export default class PostgrestTransformBuilder<
    * Query result must be one row (e.g. using `.limit(1)`), otherwise this
    * returns an error.
    */
-  single<
-    ResultOne = Result extends (infer ResultOne)[] ? ResultOne : never
-  >(): PostgrestBuilder<ResultOne> {
+  single<ResultOne = Result extends (infer ResultOne)[] ? ResultOne : never>(): PostgrestBuilder<
+    ResultOne,
+    ThrowOnError
+  > {
     this.headers['Accept'] = 'application/vnd.pgrst.object+json'
-    return this as PostgrestBuilder<ResultOne>
+    return this as unknown as PostgrestBuilder<ResultOne, ThrowOnError>
   }
 
   /**
@@ -153,7 +161,7 @@ export default class PostgrestTransformBuilder<
    */
   maybeSingle<
     ResultOne = Result extends (infer ResultOne)[] ? ResultOne : never
-  >(): PostgrestBuilder<ResultOne | null> {
+  >(): PostgrestBuilder<ResultOne | null, ThrowOnError> {
     // Temporary partial fix for https://github.com/supabase/postgrest-js/issues/361
     // Issue persists e.g. for `.insert([...]).select().maybeSingle()`
     if (this.method === 'GET') {
@@ -162,23 +170,23 @@ export default class PostgrestTransformBuilder<
       this.headers['Accept'] = 'application/vnd.pgrst.object+json'
     }
     this.isMaybeSingle = true
-    return this as PostgrestBuilder<ResultOne | null>
+    return this as unknown as PostgrestBuilder<ResultOne | null, ThrowOnError>
   }
 
   /**
    * Return `data` as a string in CSV format.
    */
-  csv(): PostgrestBuilder<string> {
+  csv(): PostgrestBuilder<string, ThrowOnError> {
     this.headers['Accept'] = 'text/csv'
-    return this as PostgrestBuilder<string>
+    return this as unknown as PostgrestBuilder<string, ThrowOnError>
   }
 
   /**
    * Return `data` as an object in [GeoJSON](https://geojson.org) format.
    */
-  geojson(): PostgrestBuilder<Record<string, unknown>> {
+  geojson(): PostgrestBuilder<Record<string, unknown>, ThrowOnError> {
     this.headers['Accept'] = 'application/geo+json'
-    return this as PostgrestBuilder<Record<string, unknown>>
+    return this as unknown as PostgrestBuilder<Record<string, unknown>, ThrowOnError>
   }
 
   /**
@@ -216,7 +224,9 @@ export default class PostgrestTransformBuilder<
     buffers?: boolean
     wal?: boolean
     format?: 'json' | 'text'
-  } = {}): PostgrestBuilder<Record<string, unknown>[]> | PostgrestBuilder<string> {
+  } = {}):
+    | PostgrestBuilder<Record<string, unknown>[], ThrowOnError>
+    | PostgrestBuilder<string, ThrowOnError> {
     const options = [
       analyze ? 'analyze' : null,
       verbose ? 'verbose' : null,
@@ -231,8 +241,9 @@ export default class PostgrestTransformBuilder<
     this.headers[
       'Accept'
     ] = `application/vnd.pgrst.plan+${format}; for="${forMediatype}"; options=${options};`
-    if (format === 'json') return this as PostgrestBuilder<Record<string, unknown>[]>
-    else return this as PostgrestBuilder<string>
+    if (format === 'json')
+      return this as unknown as PostgrestBuilder<Record<string, unknown>[], ThrowOnError>
+    else return this as unknown as PostgrestBuilder<string, ThrowOnError>
   }
 
   /**
@@ -254,7 +265,19 @@ export default class PostgrestTransformBuilder<
    *
    * @typeParam NewResult - The new result type to override with
    */
-  returns<NewResult>(): PostgrestTransformBuilder<Schema, Row, NewResult, Relationships> {
-    return this as unknown as PostgrestTransformBuilder<Schema, Row, NewResult, Relationships>
+  returns<NewResult>(): PostgrestTransformBuilder<
+    Schema,
+    Row,
+    NewResult,
+    Relationships,
+    ThrowOnError
+  > {
+    return this as unknown as PostgrestTransformBuilder<
+      Schema,
+      Row,
+      NewResult,
+      Relationships,
+      ThrowOnError
+    >
   }
 }

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -716,8 +716,8 @@ test('maybeSingle w/ throwOnError', async () => {
     .from('messages')
     .select()
     .eq('message', 'i do not exist')
-    .throwOnError()
     .maybeSingle()
+    .throwOnError()
     .then(undefined, () => {
       passes = false
     })

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -97,3 +97,14 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   const res = await postgrest.from('users').select('username, dat')
   expectType<PostgrestSingleResponse<SelectQueryError<`Referencing missing column \`dat\``>[]>>(res)
 }
+
+// throw on error
+{
+  const { data } = await postgrest
+    .from('users')
+    .select('*')
+    .returns<{ a: string; b: number }[]>()
+    .throwOnError()
+
+  expectType<{ a: string; b: number }>(data[0])
+}

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -98,13 +98,22 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   expectType<PostgrestSingleResponse<SelectQueryError<`Referencing missing column \`dat\``>[]>>(res)
 }
 
-// throw on error
+// throw on error on query
 {
-  const { data } = await postgrest
-    .from('users')
-    .select('*')
-    .returns<{ a: string; b: number }[]>()
-    .throwOnError()
+  const { data } = await postgrest.from('users').select('username').throwOnError()
+  expectType<{ username: string }[]>(data)
+}
 
-  expectType<{ a: string; b: number }>(data[0])
+// queries without throw on error have nullable results
+{
+  const { data } = await postgrest.from('users').select('username')
+  expectType<{ username: string }[] | null>(data)
+}
+
+// throw on error on client
+{
+  const strictClient = postgrest.throwOnError()
+
+  const { data } = await strictClient.from('users').select('username')
+  expectType<{ username: string }[]>(data)
 }

--- a/test/resource-embedding.ts
+++ b/test/resource-embedding.ts
@@ -1,10 +1,11 @@
 import { PostgrestClient } from '../src/index'
 import { Database } from './types'
 
-const postgrest = new PostgrestClient<Database>('http://localhost:3000')
+const postgrest = new PostgrestClient<Database>('http://localhost:3000').throwOnError()
 
 test('embedded select', async () => {
   const res = await postgrest.from('users').select('messages(*)')
+  res.data.slice()
   expect(res).toMatchInlineSnapshot(`
     Object {
       "count": null,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/supabase-js/issues/885 and https://github.com/supabase/supabase-js/issues/801 (which I guess were filed in the wrong repo)

## What is the current behavior?

1. `throwOnError()` has no effect at compile-time
2. There's no way to set a client to always throw on errors

See issues above.

## What is the new behavior?

The return type of a `.throwOnError()`'d query is always a "success" response at compile time. i.e. `error` is always null and `data` isn't unioned with `null` (though it can still be null for `.maybeSingle()` etc.)

Breaking change (albeit fairly small one): `.throwOnError()` now has to be either at the "start" or the "end" of a chain. This is no longer allowed: 

```ts
await postgrest.from('users').select('*').throwOnError().single()
```

It would have to be either:

```ts
await postgrest.from('users').select('*').single().throwOnError()
```

or the client can be configured to have all queries throw on error:

```ts
const strictClient = postgres.throwOnError()
await strictClient.from('users').select('*').single()
```

## Additional context

The motivator for me wanting this is the ugliness of littering supabase codebases with go-like `err != nil` checks:

```ts
const {data, error} = await db.from('users').select('*').eq('id', foo).single()

if (error) {
  throw error
}

console.log(`Hello ${data.username}`)
```

It gets even worse if you need multiple queries in the same scope. It's becomes awkward to alias `data` to anything meaningful, because then you also need to 

```ts
const {data: user, error: userError} = await db.from('users').select('*').eq('id', foo).single()

if (userError) {
  throw userError
}

console.log(`Hello ${data.username}`)

const {data: orders, error: ordersError} = await db.from('orders').select('*').eq('user_id', user.id)

if (ordersError) {
  throw ordersError
}
```

You also need to avoid lint rules that get angry at throwing a "raw" value without re-wrapping.

This would allow doing `export const createDBClient = () => createClient(...).throwOnError()` in a single helper, then all queries would have the throwy behaviour. The above example would become:

```ts
const {data: user} = await db.from('users').select('*').eq('id', foo).single()

console.log(`Hello ${data.username}`)

const {data: orders} = await db.from('orders').select('*').eq('user_id', user.id)
```

## Implementation

It ended up being a bigger change than I'd hoped, because the `ThrowOnError` typearg needed to be passed around everywhere. The breaking change was needed because the old `throwOnError()` implementation had a return type of `this` - and as far as I know there's no such concept in TypeScript as `this but with typearg ThrowOnError = true`. So, an abstract class can't have a method that returns a variant of its implementer - meaning the `throwOnError` method on `PostgrestBuilder` needs to return a more general `PostgrestBuilder` - which knows about the `Result` type but not about the rest of the fanciness on `PostgrestTransformBuilder`.

It might be possible to keep the old put-throwOnError-anywhere behaviour, but it would require quite a bit more fiddling and this seemed like a big enough change for me on a repo I'm not familiar with.