### PR TITLE
fix: abort signal test

### DIFF
--- a/test/transforms.ts
+++ b/test/transforms.ts
@@ -270,16 +270,22 @@ test('abort signal', async () => {
   ac.abort()
   const res = await postgrest.from('users').select().abortSignal(ac.signal)
   expect(res).toMatchInlineSnapshot(
-    { error: { details: expect.any(String) } },
+    {
+      error: {
+        code: expect.any(String),
+        details: expect.any(String),
+        message: expect.stringMatching(/^AbortError: .*/),
+      },
+    },
     `
     Object {
       "count": null,
       "data": null,
       "error": Object {
-        "code": "",
+        "code": Any<String>,
         "details": Any<String>,
         "hint": "",
-        "message": "AbortError: The user aborted a request.",
+        "message": StringMatching /\\^AbortError: \\.\\*/,
       },
       "status": 0,
       "statusText": "",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix a jest snapshot for the `abort signal` test

## What is the current behavior?

The error message on my machine doesn't quite match what's in the snapshot. This might be because of a different node version (I'm on v20.8.0), so I updated the assertion to a regex that matches either one.

## What is the new behavior?

An [asymmetric matcher](https://jestjs.io/blog/2018/05/29/jest-23-blazing-fast-delightful-testing#custom-asymmetric-matchers) for the error message. Seems like the important thing for the test to do is make sure an `AbortError` error is thrown, but not really important the exact message since it's coming from the runtime.

## Additional context

The error message I get on node v20.8.0 is `"AbortError: This operation was aborted"`. The old snapshot was for `"AbortError: The user aborted a request."`.