### PR TITLE
refactor: query parser cleanup

### DIFF
--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -110,6 +110,13 @@ type GenericStringError = ParserError<'Received a generic string'>
 export type SelectQueryError<Message extends string> = { error: true } & Message
 
 /**
+ * Creates a new {@link ParserError} if the given input is not already a parser error.
+ */
+type CreateParserErrorIfRequired<Input, Message extends string> = Input extends ParserError<string>
+  ? Input
+  : ParserError<Message>
+
+/**
  * Trims whitespace from the left of the input.
  */
 type EatWhitespace<Input extends string> = string extends Input
@@ -348,9 +355,10 @@ type ParseNode<Input extends string> = Input extends ''
     ? ParseEmbeddedResource<EatWhitespace<Remainder>> extends [infer Fields, `${infer Remainder}`]
       ? // `field!inner(nodes)`
         [{ name: Name; original: Name; children: Fields }, EatWhitespace<Remainder>]
-      : ParseEmbeddedResource<EatWhitespace<Remainder>> extends ParserError<string>
-      ? ParseEmbeddedResource<EatWhitespace<Remainder>>
-      : ParserError<'Expected embedded resource after `!inner`'>
+      : CreateParserErrorIfRequired<
+          ParseEmbeddedResource<EatWhitespace<Remainder>>,
+          'Expected embedded resource after `!inner`'
+        >
     : EatWhitespace<Remainder> extends `!${infer Remainder}`
     ? ParseIdentifier<EatWhitespace<Remainder>> extends [infer Hint, `${infer Remainder}`]
       ? EatWhitespace<Remainder> extends `!inner${infer Remainder}`
@@ -360,18 +368,20 @@ type ParseNode<Input extends string> = Input extends ''
           ]
           ? // `field!hint!inner(nodes)`
             [{ name: Name; original: Name; hint: Hint; children: Fields }, EatWhitespace<Remainder>]
-          : ParseEmbeddedResource<EatWhitespace<Remainder>> extends ParserError<string>
-          ? ParseEmbeddedResource<EatWhitespace<Remainder>>
-          : ParserError<'Expected embedded resource after `!inner`'>
+          : CreateParserErrorIfRequired<
+              ParseEmbeddedResource<EatWhitespace<Remainder>>,
+              'Expected embedded resource after `!inner`'
+            >
         : ParseEmbeddedResource<EatWhitespace<Remainder>> extends [
             infer Fields,
             `${infer Remainder}`
           ]
         ? // `field!hint(nodes)`
           [{ name: Name; original: Name; hint: Hint; children: Fields }, EatWhitespace<Remainder>]
-        : ParseEmbeddedResource<EatWhitespace<Remainder>> extends ParserError<string>
-        ? ParseEmbeddedResource<EatWhitespace<Remainder>>
-        : ParserError<'Expected embedded resource after `!hint`'>
+        : CreateParserErrorIfRequired<
+            ParseEmbeddedResource<EatWhitespace<Remainder>>,
+            'Expected embedded resource after `!hint`'
+          >
       : ParserError<'Expected identifier after `!`'>
     : EatWhitespace<Remainder> extends `:${infer Remainder}`
     ? ParseIdentifier<EatWhitespace<Remainder>> extends [infer OriginalName, `${infer Remainder}`]
@@ -389,9 +399,10 @@ type ParseNode<Input extends string> = Input extends ''
           ]
           ? // `renamed_field:field!inner(nodes)`
             [{ name: Name; original: OriginalName; children: Fields }, EatWhitespace<Remainder>]
-          : ParseEmbeddedResource<EatWhitespace<Remainder>> extends ParserError<string>
-          ? ParseEmbeddedResource<EatWhitespace<Remainder>>
-          : ParserError<'Expected embedded resource after `!inner`'>
+          : CreateParserErrorIfRequired<
+              ParseEmbeddedResource<EatWhitespace<Remainder>>,
+              'Expected embedded resource after `!inner`'
+            >
         : EatWhitespace<Remainder> extends `!${infer Remainder}`
         ? ParseIdentifier<EatWhitespace<Remainder>> extends [infer Hint, `${infer Remainder}`]
           ? EatWhitespace<Remainder> extends `!inner${infer Remainder}`
@@ -404,9 +415,10 @@ type ParseNode<Input extends string> = Input extends ''
                   { name: Name; original: OriginalName; hint: Hint; children: Fields },
                   EatWhitespace<Remainder>
                 ]
-              : ParseEmbeddedResource<EatWhitespace<Remainder>> extends ParserError<string>
-              ? ParseEmbeddedResource<EatWhitespace<Remainder>>
-              : ParserError<'Expected embedded resource after `!inner`'>
+              : CreateParserErrorIfRequired<
+                  ParseEmbeddedResource<EatWhitespace<Remainder>>,
+                  'Expected embedded resource after `!inner`'
+                >
             : ParseEmbeddedResource<EatWhitespace<Remainder>> extends [
                 infer Fields,
                 `${infer Remainder}`
@@ -421,9 +433,10 @@ type ParseNode<Input extends string> = Input extends ''
                 },
                 EatWhitespace<Remainder>
               ]
-            : ParseEmbeddedResource<EatWhitespace<Remainder>> extends ParserError<string>
-            ? ParseEmbeddedResource<EatWhitespace<Remainder>>
-            : ParserError<'Expected embedded resource after `!hint`'>
+            : CreateParserErrorIfRequired<
+                ParseEmbeddedResource<EatWhitespace<Remainder>>,
+                'Expected embedded resource after `!hint`'
+              >
           : ParserError<'Expected identifier after `!`'>
         : ParseEmbeddedResource<EatWhitespace<Remainder>> extends [
             infer Fields,

--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -118,6 +118,9 @@ type EatWhitespace<Input extends string> = string extends Input
   ? EatWhitespace<Remainder>
   : Input
 
+/**
+ * Returns a boolean representing whether there is a foreign key with the given name.
+ */
 type HasFKey<FKeyName, Relationships> = Relationships extends [infer R]
   ? R extends { foreignKeyName: FKeyName }
     ? true
@@ -128,6 +131,9 @@ type HasFKey<FKeyName, Relationships> = Relationships extends [infer R]
     : HasFKey<FKeyName, Rest>
   : false
 
+/**
+ * Returns a boolean representing whether there the foreign key has a unique constraint.
+ */
 type HasUniqueFKey<FKeyName, Relationships> = Relationships extends [infer R]
   ? R extends { foreignKeyName: FKeyName; isOneToOne: true }
     ? true
@@ -138,6 +144,10 @@ type HasUniqueFKey<FKeyName, Relationships> = Relationships extends [infer R]
     : HasUniqueFKey<FKeyName, Rest>
   : false
 
+/**
+ * Returns a boolean representing whether there is a foreign key referencing
+ * a given relation.
+ */
 type HasFKeyToFRel<FRelName, Relationships> = Relationships extends [infer R]
   ? R extends { referencedRelation: FRelName }
     ? true
@@ -161,8 +171,9 @@ type HasUniqueFKeyToFRel<FRelName, Relationships> = Relationships extends [infer
 /**
  * Constructs a type definition for a single field of an object.
  *
- * @param Definitions Record of definitions, possibly generated from PostgREST's OpenAPI spec.
- * @param Name Name of the table being queried.
+ * @param Schema Database schema.
+ * @param Row Type of a row in the given table.
+ * @param Relationships Relationships between different tables in the database.
  * @param Field Single field parsed by `ParseQuery`.
  */
 type ConstructFieldDefinition<
@@ -246,8 +257,7 @@ type ConstructFieldDefinition<
  */
 
 /**
- * Reads a consecutive sequence of more than 1 letter,
- * where letters are `[0-9a-zA-Z_]`.
+ * Reads a consecutive sequence of 1 or more letter, where letters are `[0-9a-zA-Z_]`.
  */
 type ReadLetters<Input extends string> = string extends Input
   ? GenericStringError
@@ -266,7 +276,7 @@ type ReadLettersHelper<Input extends string, Acc extends string> = string extend
   : [Acc, '']
 
 /**
- * Reads a consecutive sequence of more than 1 double-quoted letters,
+ * Reads a consecutive sequence of 1 or more double-quoted letters,
  * where letters are `[^"]`.
  */
 type ReadQuotedLetters<Input extends string> = string extends Input
@@ -289,7 +299,7 @@ type ReadQuotedLettersHelper<Input extends string, Acc extends string> = string 
 
 /**
  * Parses a (possibly double-quoted) identifier.
- * For now, identifiers are just sequences of more than 1 letter.
+ * Identifiers are sequences of 1 or more letters.
  */
 type ParseIdentifier<Input extends string> = ReadLetters<Input> extends [
   infer Name,
@@ -560,7 +570,9 @@ type GetResultHelper<
 /**
  * Constructs a type definition for an object based on a given PostgREST query.
  *
- * @param Row Record<string, unknown>.
+ * @param Schema Database schema.
+ * @param Row Type of a row in the given table.
+ * @param Relationships Relationships between different tables in the database.
  * @param Query Select query string literal to parse.
  */
 export type GetResult<


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the current behavior?

There is a lot of duplicated code in the query parser, due to the field and renamed field parsing sharing the same code.

## What is the new behavior?
The parsing of a field is extracted out to a separate `ParseField` helper, which can be reused to detect both a renamed field and non-renamed fields. I also updated some comments for accuracy.
