### PR TITLE
feat: query parser: add types for `count`

### DIFF
--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -267,6 +267,8 @@ type ConstructFieldDefinition<
   : Field extends { name: string; original: string }
   ? Field['original'] extends keyof Row
     ? { [K in Field['name']]: Row[Field['original']] }
+    : Field['original'] extends 'count'
+    ? { count: number }
     : SelectQueryError<`Referencing missing column \`${Field['original']}\``>
   : Record<string, unknown>
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -88,6 +88,15 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   expectType<{ message: string | null }>(data)
 }
 
+// `count` in embedded resource
+{
+  const { data, error } = await postgrest.from('messages').select('message, users(count)').single()
+  if (error) {
+    throw new Error(error.message)
+  }
+  expectType<{ message: string | null; users: { count: number } | null }>(data)
+}
+
 // json accessor in select query
 {
   const { data, error } = await postgrest


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The types for select queries do not have types for `count` since it is not a column of the table.

## What is the new behavior?

Types for `count` are added to all tables, since it is an aggregate which supported by PostgREST and is widely used in the Supabase-js documentation as well.

## Additional context
This PR is stacked on top of #497.
Closes https://github.com/supabase/postgrest-js/issues/447, https://github.com/supabase/postgrest-js/issues/479.

I'm not sure if the handling of the cardinality is correct for this.