### PR TITLE
feat: query parser: handle empty embedded resources `()`

### DIFF
--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -79,6 +79,15 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   )
 }
 
+// embedded resource with no fields
+{
+  const { data, error } = await postgrest.from('messages').select('message, users()').single()
+  if (error) {
+    throw new Error(error.message)
+  }
+  expectType<{ message: string | null }>(data)
+}
+
 // json accessor in select query
 {
   const { data, error } = await postgrest


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

Empty embedded resources, which were added in PostgREST v11, are not supported by the select query parser.

## What is the new behavior?

Support is added for empty embedded resources.

## Additional context
This PR is stacked on top of #497.

Closes https://github.com/supabase/postgrest-js/issues/445.