### PR TITLE
Fix errors with verbatimModuleSyntax

### DIFF
--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -2,7 +2,7 @@ import PostgrestQueryBuilder from './PostgrestQueryBuilder'
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 import PostgrestBuilder from './PostgrestBuilder'
 import { DEFAULT_HEADERS } from './constants'
-import { Fetch, GenericSchema } from './types'
+import type { Fetch, GenericSchema } from './types'
 
 /**
  * PostgREST client.

--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -1,5 +1,5 @@
 import PostgrestTransformBuilder from './PostgrestTransformBuilder'
-import { GenericSchema } from './types'
+import type { GenericSchema } from './types'
 
 type FilterOperator =
   | 'eq'

--- a/src/PostgrestQueryBuilder.ts
+++ b/src/PostgrestQueryBuilder.ts
@@ -1,7 +1,7 @@
 import PostgrestBuilder from './PostgrestBuilder'
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
-import { GetResult } from './select-query-parser'
-import { Fetch, GenericSchema, GenericTable, GenericView } from './types'
+import type { GetResult } from './select-query-parser'
+import type { Fetch, GenericSchema, GenericTable, GenericView } from './types'
 
 export default class PostgrestQueryBuilder<
   Schema extends GenericSchema,

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -1,6 +1,6 @@
 import PostgrestBuilder from './PostgrestBuilder'
-import { GetResult } from './select-query-parser'
-import { GenericSchema } from './types'
+import type { GetResult } from './select-query-parser'
+import type { GenericSchema } from './types'
 
 export default class PostgrestTransformBuilder<
   Schema extends GenericSchema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export { default as PostgrestQueryBuilder } from './PostgrestQueryBuilder'
 export { default as PostgrestFilterBuilder } from './PostgrestFilterBuilder'
 export { default as PostgrestTransformBuilder } from './PostgrestTransformBuilder'
 export { default as PostgrestBuilder } from './PostgrestBuilder'
-export {
+export type {
   PostgrestResponse,
   PostgrestResponseFailure,
   PostgrestResponseSuccess,

--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -1,6 +1,6 @@
 // Credits to @bnjmnt4n (https://www.npmjs.com/package/postgrest-query)
 
-import { GenericSchema, Prettify } from './types'
+import type { GenericSchema, Prettify } from './types'
 
 type Whitespace = ' ' | '\n' | '\t'
 


### PR DESCRIPTION
This pull request fixes errors that occur when verbatimModuleSyntax is enabled in tsconfig.json. The affected types now use type-only import syntax.
