### PR TITLE
fix: explain() always returning an error

### DIFF
--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -267,7 +267,7 @@ export default class PostgrestTransformBuilder<
       .filter(Boolean)
       .join('|')
     // An Accept header can carry multiple media types but postgrest-js always sends one
-    const forMediatype = this.headers['Accept']
+    const forMediatype = this.headers['Accept'] ?? 'application/json'
     this.headers[
       'Accept'
     ] = `application/vnd.pgrst.plan+${format}; for="${forMediatype}"; options=${options};`

--- a/test/db/docker-compose.yml
+++ b/test/db/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3'
 services:
   rest:
-    image: postgrest/postgrest:v11.0.0
+    image: postgrest/postgrest:v11.2.2
     ports:
       - '3000:3000'
     environment:

--- a/test/transforms.ts
+++ b/test/transforms.ts
@@ -200,7 +200,7 @@ test('maybeSingle', async () => {
       "data": null,
       "error": Object {
         "code": "PGRST116",
-        "details": "Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row",
+        "details": "The result contains 2 rows",
         "hint": null,
         "message": "JSON object requested, multiple (or no) rows returned",
       },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Closes #504

## What is the current behavior?

Sends `"undefined"` media type when requesting explain plan, making the explain() method fail.

## What is the new behavior?

Sends `"application/json"` as media type.

## Additional context

Tests weren't failing because they were using PostgREST v11.0.0 instead of v11.2.2
