### PR TITLE
fix: add link on how to enable explain on the explain() method

### DIFF
--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -224,6 +224,12 @@ export default class PostgrestTransformBuilder<
   /**
    * Return `data` as the EXPLAIN plan for the query.
    *
+   * Before using this method, you need to enable `explain()` on your
+   * Supabase instance by following the guide below. Note that `explain()`
+   * should only be enabled on an development environment.
+   *
+   * https://supabase.com/docs/guides/api/rest/debugging-performance#enabling-explain
+   *
    * @param options - Named parameters
    *
    * @param options.analyze - If `true`, the query will be executed and the

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -224,11 +224,7 @@ export default class PostgrestTransformBuilder<
   /**
    * Return `data` as the EXPLAIN plan for the query.
    *
-   * Before using this method, you need to enable `explain()` on your
-   * Supabase instance by following the guide below. Note that `explain()`
-   * should only be enabled on an development environment.
-   *
-   * https://supabase.com/docs/guides/api/rest/debugging-performance#enabling-explain
+   * You need to set `pgrst.db_plan_enabled` to `true` before using this method.
    *
    * @param options - Named parameters
    *

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -224,7 +224,9 @@ export default class PostgrestTransformBuilder<
   /**
    * Return `data` as the EXPLAIN plan for the query.
    *
-   * You need to set `pgrst.db_plan_enabled` to `true` before using this method.
+   * You need to enable the
+   * [db_plan_enabled](https://supabase.com/docs/guides/database/debugging-performance#enabling-explain)
+   * setting before using this method.
    *
    * @param options - Named parameters
    *


### PR DESCRIPTION
## What kind of change does this PR introduce?

Thought it would be helpful to include a link on how to enable the `explain()` feature on the method itself so that people know how to enable it. 