### PR TITLE
dedup values passed to PostgrestFilterBuilder.in

### DIFF
--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -239,7 +239,7 @@ export default class PostgrestFilterBuilder<
    * @param values - The values array to filter with
    */
   in(column: string, values: readonly unknown[]): this {
-    const cleanedValues = values
+    const cleanedValues = Array.from(new Set(values))
       .map((s) => {
         // handle postgrest reserved characters
         // https://postgrest.org/en/v7.0.0/api.html#reserved-characters


### PR DESCRIPTION
## What kind of change does this PR introduce?

Dedup values passed into  PostgrestFilterBuilder.in

## What is the current behavior?

Values are incorporated into the url as is when duplicate values are present.  
e.g. .in([1,1,2,2,3,3]) => `in.(1,1,2,2,3,3)`

The caused us to get a 414 URI too long when we passed in a long array of deduplicated values by accident.  Would be nice if the library took care of this.

## What is the new behavior?

Values will be deduplicated as duplicated.  
e.g. .in([1,1,2,2,3,3]) => `in.(1,2,3)`


