### PR TITLE
feat: query parser: Add support for aggregate functions

### DIFF
--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -112,6 +112,25 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   expectType<string>(data.baz)
 }
 
+// typecasting and aggregate functions
+{
+  const { data, error } = await postgrest
+    .from('messages')
+    .select(
+      'message, users.count(), casted_message:message::int4, casted_count:users.count()::text'
+    )
+    .single()
+  if (error) {
+    throw new Error(error.message)
+  }
+  expectType<{
+    message: string | null
+    count: number
+    casted_message: number
+    casted_count: string
+  }>(data)
+}
+
 // rpc return type
 {
   const { data, error } = await postgrest.rpc('get_status')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

[Aggregate functions](https://supabase.com/blog/postgrest-aggregate-functions), added in Postgrest v12, are not supported in the query parser.

## What is the new behavior?

Aggregate functions are now supported in the query parser.

## Additional context

Closes #520.

I also split out some of logic into separate helper types and added more docs to make it slightly more comprehensible.