### PR TITLE
Allow to pass Next.js options to fetch while building query

### DIFF
--- a/src/PostgrestBuilder.ts
+++ b/src/PostgrestBuilder.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import nodeFetch from '@supabase/node-fetch'
 
-import type { Fetch, PostgrestSingleResponse } from './types'
+import type { Fetch, NextFetchRequestConfig, PostgrestSingleResponse } from './types'
 import PostgrestError from './PostgrestError'
 
 export default abstract class PostgrestBuilder<Result>
@@ -14,6 +14,7 @@ export default abstract class PostgrestBuilder<Result>
   protected body?: unknown
   protected shouldThrowOnError = false
   protected signal?: AbortSignal
+  protected nextOptions?: NextFetchRequestConfig
   protected fetch: Fetch
   protected isMaybeSingle: boolean
 
@@ -25,6 +26,7 @@ export default abstract class PostgrestBuilder<Result>
     this.body = builder.body
     this.shouldThrowOnError = builder.shouldThrowOnError
     this.signal = builder.signal
+    this.nextOptions = builder.nextOptions
     this.isMaybeSingle = builder.isMaybeSingle
 
     if (builder.fetch) {
@@ -74,6 +76,7 @@ export default abstract class PostgrestBuilder<Result>
       headers: this.headers,
       body: JSON.stringify(this.body),
       signal: this.signal,
+      next: this.nextOptions,
     }).then(async (res) => {
       let error = null
       let data = null

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -1,6 +1,6 @@
 import PostgrestBuilder from './PostgrestBuilder'
 import { GetResult } from './select-query-parser'
-import { GenericSchema } from './types'
+import { GenericSchema, NextFetchRequestConfig } from './types'
 
 export default class PostgrestTransformBuilder<
   Schema extends GenericSchema,
@@ -179,6 +179,17 @@ export default class PostgrestTransformBuilder<
    */
   abortSignal(signal: AbortSignal): this {
     this.signal = signal
+    return this
+  }
+
+  /**
+   * Set Next.js's tags for the fetch request.
+   *
+   * @param tags - An array of tags. A tag represents the cache tag associated with the data.
+   * Must be less than or equal to 256 characters. This value is case-sensitive.
+   */
+  next(nextOptions: NextFetchRequestConfig): this {
+    this.nextOptions = nextOptions
     return this
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,3 +70,18 @@ export type GenericSchema = {
 
 // https://twitter.com/mattpocockuk/status/1622730173446557697
 export type Prettify<T> = { [K in keyof T]: T[K] } & {}
+
+export type NextFetchRequestConfig = RequestInit extends { next: infer T }
+  ? T
+  : {
+      revalidate?: number | false
+      tags?: string[]
+    }
+
+declare global {
+  namespace globalThis {
+    interface RequestInit {
+      next?: unknown // Avoid: 'next' is referenced directly or indirectly in its own type annotation.ts(2502)
+    }
+  }
+}

--- a/test/transforms.ts
+++ b/test/transforms.ts
@@ -473,3 +473,51 @@ test('rollback delete', async () => {
     }
   `)
 })
+
+test('Next.js options', async () => {
+  const fetchSpy = jest.fn(fetch)
+
+  const postgrest = new PostgrestClient<Database>('http://localhost:3000', {
+    fetch: fetchSpy,
+  })
+
+  const builder = postgrest
+    .from('users')
+    .select()
+    .eq('username', 'supabot')
+    .next({
+      tags: ['users', 'supabot'],
+    })
+  const res = await builder
+  expect(res).toMatchInlineSnapshot(`
+    Object {
+      "count": null,
+      "data": Array [
+        Object {
+          "age_range": "[1,2)",
+          "catchphrase": "'cat' 'fat'",
+          "data": null,
+          "status": "ONLINE",
+          "username": "supabot",
+        },
+      ],
+      "error": null,
+      "status": 200,
+      "statusText": "OK",
+    }
+  `)
+  expect(fetchSpy).toHaveBeenCalledWith(
+    'http://localhost:3000/users?select=*&username=eq.supabot',
+    {
+      body: undefined,
+      headers: {
+        'X-Client-Info': 'postgrest-js/0.0.0-automated',
+      },
+      method: 'GET',
+      next: {
+        tags: ['users', 'supabot'],
+      },
+      signal: undefined,
+    }
+  )
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

This adds a possibility to pass `next` options to [fetch](https://nextjs.org/docs/app/api-reference/functions/fetch#optionsnextrevalidate) while building query.

Arguably there could be possibility to overwrite _any_ `RequestInit` options, e.g. [`cf`](https://developers.cloudflare.com/workers/runtime-apis/request/#the-cf-property-requestinitcfproperties). There would have to be some strategy to merge these with defaults, but it could offer more flexibility. 

## What is the current behavior?

Currently we can pass fetch at `PostgrestBuilder` creation. Which effectively means once, if using Supabase. One would have to parse URL and build tags in central place.

```ts
  const postgrest2 = new PostgrestClient<Database>('http://localhost:3000', {
    fetch: (url, init) => {
      let parsedUrl: URL

      if (url instanceof URL) {
        parsedUrl = url
      } else if (typeof url === 'string') {
        parsedUrl = new URL(url)
      } else {
        parsedUrl = new URL(url.url)
      }

      const tags: string[] = []
      if (parsedUrl.pathname.startsWith('/rest')) {
        const [,, entity] = parsedUrl.pathname.split('/').slice(1)
        tags.push(entity)
      }

      return fetch(url, {
        ...init,
        next: {
          tags,
        },
      })
    },
  })

```

## What is the new behavior?

Allow to pass `next` options when building query. The idea here is 

```ts
  const res = await postgrest
    .from('users')
    .select()
    .eq('username', 'supabot')
    .next({
      tags: ['users/supabot'],
    })

// ... later in the code

revalidateTag('users/supabot');
```


