### PR TITLE
feat: `.rpc()` with GET

### DIFF
--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -107,6 +107,8 @@ export default class PostgrestClient<
    * @param options - Named parameters
    * @param options.head - When set to `true`, `data` will not be returned.
    * Useful if you only need the count.
+   * @param options.get - When set to `true`, the function will be called with
+   * read-only access mode.
    * @param options.count - Count algorithm to use to count rows returned by the
    * function. Only applicable for [set-returning
    * functions](https://www.postgresql.org/docs/current/functions-srf.html).
@@ -128,9 +130,11 @@ export default class PostgrestClient<
     args: Function_['Args'] = {},
     {
       head = false,
+      get = false,
       count,
     }: {
       head?: boolean
+      get?: boolean
       count?: 'exact' | 'planned' | 'estimated'
     } = {}
   ): PostgrestFilterBuilder<
@@ -142,11 +146,16 @@ export default class PostgrestClient<
       : never,
     Function_['Returns']
   > {
-    let method: 'HEAD' | 'POST'
+    let method: 'HEAD' | 'GET' | 'POST'
     const url = new URL(`${this.url}/rpc/${fn}`)
     let body: unknown | undefined
     if (head) {
       method = 'HEAD'
+      Object.entries(args).forEach(([name, value]) => {
+        url.searchParams.append(name, `${value}`)
+      })
+    } else if (get) {
+      method = 'GET'
       Object.entries(args).forEach(([name, value]) => {
         url.searchParams.append(name, `${value}`)
       })

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -914,6 +914,23 @@ test('rpc with head:true, count:exact', async () => {
   `)
 })
 
+test('rpc with get:true, count:exact', async () => {
+  const res = await postgrest.rpc(
+    'get_status',
+    { name_param: 'supabot' },
+    { get: true, count: 'exact' }
+  )
+  expect(res).toMatchInlineSnapshot(`
+    Object {
+      "count": 1,
+      "data": "ONLINE",
+      "error": null,
+      "status": 200,
+      "statusText": "OK",
+    }
+  `)
+})
+
 test('rpc with dynamic schema', async () => {
   const res = await postgrest.schema('personal').rpc('get_status', { name_param: 'kiwicopple' })
   expect(res).toMatchInlineSnapshot(`

--- a/test/transforms.ts
+++ b/test/transforms.ts
@@ -270,16 +270,22 @@ test('abort signal', async () => {
   ac.abort()
   const res = await postgrest.from('users').select().abortSignal(ac.signal)
   expect(res).toMatchInlineSnapshot(
-    { error: { details: expect.any(String) } },
+    {
+      error: {
+        code: expect.any(String),
+        details: expect.any(String),
+        message: expect.stringMatching(/^AbortError:/),
+      },
+    },
     `
     Object {
       "count": null,
       "data": null,
       "error": Object {
-        "code": "",
+        "code": Any<String>,
         "details": Any<String>,
         "hint": "",
-        "message": "AbortError: The user aborted a request.",
+        "message": StringMatching /\\^AbortError:/,
       },
       "status": 0,
       "statusText": "",


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

No way to use `.rpc()` with GET

## What is the new behavior?

The request will be performed with GET when using `.rpc()` with `get: true`.

## Additional context

In read-replica setups, it's common to deny POST/PATCH/etc. on the API gateway level. PostgREST allows performing queries in read-only access mode via stable/immutable functions, but it wouldn't work on this read-replica setup.
