### PR TITLE
detect !inner in one-to-one relationships

### DIFF
--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -228,7 +228,9 @@ type ConstructFieldDefinition<
               ? R
               : unknown
           > extends true
-          ? Child | null
+          ? Field extends { inner: true }
+            ? Child
+            : Child | null
           : Relationships extends unknown[]
           ? HasFKey<Field['hint'], Relationships> extends true
             ? Field extends { inner: true }
@@ -259,7 +261,9 @@ type ConstructFieldDefinition<
               ? R
               : unknown
           > extends true
-          ? Child | null
+          ? Field extends { inner: true }
+            ? Child
+            : Child | null
           : Relationships extends unknown[]
           ? HasFKeyToFRel<Field['original'], Relationships> extends true
             ? Field extends { inner: true }

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -154,12 +154,18 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
 {
   const { data: message, error } = await postgrest
     .from('messages')
-    .select('user:users!inner(*)')
+    .select('channels!inner(*, channel_details!inner(*))')
     .single()
   if (error) {
     throw new Error(error.message)
   }
-  expectType<Database['public']['Tables']['users']['Row']>(message.user)
+  type ExpectedType = Prettify<
+    Database['public']['Tables']['channels']['Row'] & {
+      channel_details: Database['public']['Tables']['channel_details']['Row']
+    }
+  >
+
+  expectType<ExpectedType>(message.channels)
 }
 
 // one-to-many relationship


### PR DESCRIPTION
## What kind of change does this PR introduce?

Select query type parser feature/bugfix

## What is the current behavior?

```ts
.select("a_onetoone_rel!inner(*)")
```

results in a nullable `a_onetoone_rel`, while it should be non-nullable due to `!inner`

## What is the new behavior?

Detects this case and removes nullability of the inner one-to-one relationship.

## Additional context

non one-to-one case was fixed in #458
