### PR TITLE
#523 fix typescript error for aggregate functions

### DIFF
--- a/src/select-query-parser.ts
+++ b/src/select-query-parser.ts
@@ -274,8 +274,8 @@ type ConstructFieldDefinition<
   : Field extends { name: string; original: string }
   ? Field['original'] extends keyof Row
     ? { [K in Field['name']]: Row[Field['original']] }
-    : Field['original'] extends 'count'
-    ? { count: number }
+    : Field['original'] extends AggregateFunctions
+    ? { [K in Field['original']]: number }
     : SelectQueryError<`Referencing missing column \`${Field['original']}\``>
   : Record<string, unknown>
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -89,13 +89,31 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   expectType<{ message: string | null }>(data)
 }
 
-// `count` in embedded resource
+// aggregate functions in embedded resources
 {
   const { data, error } = await postgrest.from('messages').select('message, users(count)').single()
-  if (error) {
-    throw new Error(error.message)
-  }
+  if (error) throw new Error(error.message)
   expectType<{ message: string | null; users: { count: number } | null }>(data)
+}
+{
+  const { data, error } = await postgrest.from('messages').select('message, users(sum)').single()
+  if (error) throw new Error(error.message)
+  expectType<{ message: string | null; users: { sum: number } | null }>(data)
+}
+{
+  const { data, error } = await postgrest.from('messages').select('message, users(min)').single()
+  if (error) throw new Error(error.message)
+  expectType<{ message: string | null; users: { min: number } | null }>(data)
+}
+{
+  const { data, error } = await postgrest.from('messages').select('message, users(max)').single()
+  if (error) throw new Error(error.message)
+  expectType<{ message: string | null; users: { max: number } | null }>(data)
+}
+{
+  const { data, error } = await postgrest.from('messages').select('message, users(avg)').single()
+  if (error) throw new Error(error.message)
+  expectType<{ message: string | null; users: { avg: number } | null }>(data)
 }
 
 // json accessor in select query


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix dynamic TypeScript type for `data` when using aggregate functions other than `count`

## What is the current behavior?
Aggregate functions other than `count` will result in TypeScript errors for the resulting type of `data` (#523)

Bug fix for issues:
- #523 
- #524 (potentially, not tested explicitly)

## What is the new behavior?

Using the other aggregate functions "sum", "avg", "min", and "max" will not result in an erroneous TypeScript type for `data`.

## Additional context

I just generalized changes from #520 by @bnjmnt4n ; thanks for your work!
