### PR TITLE
fix: ignore undefined args when using rpc with head/get

### DIFF
--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -150,14 +150,18 @@ export default class PostgrestClient<
     let body: unknown | undefined
     if (head) {
       method = 'HEAD'
-      Object.entries(args).forEach(([name, value]) => {
-        url.searchParams.append(name, `${value}`)
-      })
+      Object.entries(args)
+        .filter(([_, value]) => value !== undefined)
+        .forEach(([name, value]) => {
+          url.searchParams.append(name, `${value}`)
+        })
     } else if (get) {
       method = 'GET'
-      Object.entries(args).forEach(([name, value]) => {
-        url.searchParams.append(name, `${value}`)
-      })
+      Object.entries(args)
+        .filter(([_, value]) => value !== undefined)
+        .forEach(([name, value]) => {
+          url.searchParams.append(name, `${value}`)
+        })
     } else {
       method = 'POST'
       body = args

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -121,12 +121,9 @@ export default class PostgrestClient<
    * `"estimated"`: Uses exact count for low numbers and planned count for high
    * numbers.
    */
-  rpc<
-    FunctionName extends string & keyof Schema['Functions'],
-    Function_ extends Schema['Functions'][FunctionName]
-  >(
-    fn: FunctionName,
-    args: Function_['Args'] = {},
+  rpc<FnName extends string & keyof Schema['Functions'], Fn extends Schema['Functions'][FnName]>(
+    fn: FnName,
+    args: Fn['Args'] = {},
     {
       head = false,
       get = false,
@@ -138,12 +135,12 @@ export default class PostgrestClient<
     } = {}
   ): PostgrestFilterBuilder<
     Schema,
-    Function_['Returns'] extends any[]
-      ? Function_['Returns'][number] extends Record<string, unknown>
-        ? Function_['Returns'][number]
+    Fn['Returns'] extends any[]
+      ? Fn['Returns'][number] extends Record<string, unknown>
+        ? Fn['Returns'][number]
         : never
       : never,
-    Function_['Returns']
+    Fn['Returns']
   > {
     let method: 'HEAD' | 'GET' | 'POST'
     const url = new URL(`${this.url}/rpc/${fn}`)
@@ -180,6 +177,6 @@ export default class PostgrestClient<
       body,
       fetch: this.fetch,
       allowEmpty: false,
-    } as unknown as PostgrestBuilder<Function_['Returns']>)
+    } as unknown as PostgrestBuilder<Fn['Returns']>)
   }
 }

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -933,6 +933,23 @@ test('rpc with get:true, count:exact', async () => {
   `)
 })
 
+test('rpc with get:true, optional param', async () => {
+  const res = await postgrest.rpc(
+    'function_with_optional_param',
+    { param: undefined },
+    { get: true }
+  )
+  expect(res).toMatchInlineSnapshot(`
+    Object {
+      "count": null,
+      "data": "",
+      "error": null,
+      "status": 200,
+      "statusText": "OK",
+    }
+  `)
+})
+
 test('rpc with dynamic schema', async () => {
   const res = await postgrest.schema('personal').rpc('get_status', { name_param: 'kiwicopple' })
   expect(res).toMatchInlineSnapshot(`

--- a/test/db/00-schema.sql
+++ b/test/db/00-schema.sql
@@ -91,3 +91,8 @@ CREATE FUNCTION personal.get_status(name_param text)
 RETURNS user_status AS $$
   SELECT status from users WHERE username=name_param;
 $$ LANGUAGE SQL IMMUTABLE;
+
+create function public.function_with_optional_param(param text default '')
+returns text as $$
+  select param;
+$$ language sql immutable;

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,6 +1,6 @@
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
 
-export interface Database {
+export type Database = {
   personal: {
     Tables: {
       users: {
@@ -112,25 +112,29 @@ export interface Database {
           {
             foreignKeyName: 'messages_channel_id_fkey'
             columns: ['channel_id']
+            isOneToOne: false
             referencedRelation: 'channels'
             referencedColumns: ['id']
           },
           {
             foreignKeyName: 'messages_username_fkey'
             columns: ['username']
-            referencedRelation: 'users'
-            referencedColumns: ['username']
-          },
-          {
-            foreignKeyName: 'messages_username_fkey'
-            columns: ['username']
+            isOneToOne: false
             referencedRelation: 'non_updatable_view'
             referencedColumns: ['username']
           },
           {
             foreignKeyName: 'messages_username_fkey'
             columns: ['username']
+            isOneToOne: false
             referencedRelation: 'updatable_view'
+            referencedColumns: ['username']
+          },
+          {
+            foreignKeyName: 'messages_username_fkey'
+            columns: ['username']
+            isOneToOne: false
+            referencedRelation: 'users'
             referencedColumns: ['username']
           }
         ]
@@ -202,6 +206,12 @@ export interface Database {
       }
     }
     Functions: {
+      function_with_optional_param: {
+        Args: {
+          param?: string
+        }
+        Returns: string
+      }
       get_status: {
         Args: {
           name_param: string
@@ -236,3 +246,77 @@ export interface Database {
     }
   }
 }
+
+type PublicSchema = Database[Extract<keyof Database, 'public'>]
+
+export type Tables<
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema['Tables'] & PublicSchema['Views'])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions['schema']]['Tables'] &
+        Database[PublicTableNameOrOptions['schema']]['Views'])
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions['schema']]['Tables'] &
+      Database[PublicTableNameOrOptions['schema']]['Views'])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views'])
+  ? (PublicSchema['Tables'] & PublicSchema['Views'])[PublicTableNameOrOptions] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : never
+
+export type TablesInsert<
+  PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
+  ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : never
+
+export type TablesUpdate<
+  PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
+  ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : never
+
+export type Enums<
+  PublicEnumNameOrOptions extends keyof PublicSchema['Enums'] | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions['schema']]['Enums']
+    : never = never
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema['Enums']
+  ? PublicSchema['Enums'][PublicEnumNameOrOptions]
+  : never


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

This isn't an issue on `POST` because upon `JSON.stringify()`, all object fields with a value of `undefined` gets omitted
