### PR TITLE
fix: rpc w/ HEAD/GET w/ array param

### DIFF
--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -145,19 +145,16 @@ export default class PostgrestClient<
     let method: 'HEAD' | 'GET' | 'POST'
     const url = new URL(`${this.url}/rpc/${fn}`)
     let body: unknown | undefined
-    if (head) {
-      method = 'HEAD'
+    if (head || get) {
+      method = head ? 'HEAD' : 'GET'
       Object.entries(args)
+        // params with undefined value needs to be filtered out, otherwise it'll
+        // show up as `?param=undefined`
         .filter(([_, value]) => value !== undefined)
+        // array values need special syntax
+        .map(([name, value]) => [name, Array.isArray(value) ? `{${value.join(',')}}` : `${value}`])
         .forEach(([name, value]) => {
-          url.searchParams.append(name, `${value}`)
-        })
-    } else if (get) {
-      method = 'GET'
-      Object.entries(args)
-        .filter(([_, value]) => value !== undefined)
-        .forEach(([name, value]) => {
-          url.searchParams.append(name, `${value}`)
+          url.searchParams.append(name, value)
         })
     } else {
       method = 'POST'

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -950,6 +950,23 @@ test('rpc with get:true, optional param', async () => {
   `)
 })
 
+test('rpc with get:true, array param', async () => {
+  const res = await postgrest.rpc(
+    'function_with_array_param',
+    { param: ['00000000-0000-0000-0000-000000000000'] },
+    { get: true }
+  )
+  expect(res).toMatchInlineSnapshot(`
+    Object {
+      "count": null,
+      "data": null,
+      "error": null,
+      "status": 204,
+      "statusText": "No Content",
+    }
+  `)
+})
+
 test('rpc with dynamic schema', async () => {
   const res = await postgrest.schema('personal').rpc('get_status', { name_param: 'kiwicopple' })
   expect(res).toMatchInlineSnapshot(`

--- a/test/db/00-schema.sql
+++ b/test/db/00-schema.sql
@@ -96,3 +96,6 @@ create function public.function_with_optional_param(param text default '')
 returns text as $$
   select param;
 $$ language sql immutable;
+
+create function public.function_with_array_param(param uuid[])
+returns void as '' language sql immutable;

--- a/test/types.ts
+++ b/test/types.ts
@@ -206,6 +206,12 @@ export type Database = {
       }
     }
     Functions: {
+      function_with_array_param: {
+        Args: {
+          param: string[]
+        }
+        Returns: undefined
+      }
       function_with_optional_param: {
         Args: {
           param?: string


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

rpc() with HEAD/GET using an array param gives a `malformed array literal` error
