### PR TITLE
fix: "Cannot destructure property 'PostgrestClient'" error

### DIFF
--- a/wrapper.mjs
+++ b/wrapper.mjs
@@ -1,11 +1,10 @@
-import index from '../cjs/index.js'
-const {
+import {
   PostgrestClient,
   PostgrestQueryBuilder,
   PostgrestFilterBuilder,
   PostgrestTransformBuilder,
   PostgrestBuilder,
-} = index
+} from '../cjs/index.js'
 
 export {
   PostgrestBuilder,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Getting an error here:

```
Cannot destructure property 'PostgrestClient' of '_index.default' as it is undefined.
```

because index.ts is only exporting named exports with no default export.

## What is the new behavior?

Import works as expected, and I can create a SupabaseClient
