### PR TITLE
Update PostgrestClient.ts to allow for additional headers on-demand

### DIFF
--- a/src/PostgrestBuilder.ts
+++ b/src/PostgrestBuilder.ts
@@ -47,6 +47,15 @@ export default abstract class PostgrestBuilder<Result>
     return this
   }
 
+  /**
+   * Set an HTTP header for the request.
+   */
+  setHeader(name: string, value: string): this {
+    this.headers = { ...this.headers }
+    this.headers[name] = value
+    return this
+  }
+
   then<TResult1 = PostgrestSingleResponse<Result>, TResult2 = never>(
     onfulfilled?:
       | ((value: PostgrestSingleResponse<Result>) => TResult1 | PromiseLike<TResult1>)

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -107,6 +107,15 @@ test('custom headers', async () => {
   expect((postgrest.from('users').select() as any).headers['apikey']).toEqual('foo')
 })
 
+test('custom headers on a per-call basis', async () => {
+  const postgrest1 = new PostgrestClient<Database>(REST_URL, { headers: { apikey: 'foo' } })
+  const postgrest2 = postgrest1.rpc('void_func').setHeader('apikey', 'bar')
+  // Original client object isn't affected
+  expect((postgrest1.from('users').select() as any).headers['apikey']).toEqual('foo')
+  // Derived client object uses new header value
+  expect((postgrest2 as any).headers['apikey']).toEqual('bar')
+})
+
 describe('custom prefer headers with ', () => {
   test('insert', async () => {
     const postgrest = new PostgrestClient<Database>(REST_URL, {

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -196,3 +196,12 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
     channels.channel_details
   )
 }
+
+// PostgrestBuilder's children retains class when using inherited methods
+{
+  const x = postgrest.from('channels').select()
+  const y = x.throwOnError()
+  const z = x.setHeader('', '')
+  expectType<typeof x>(y)
+  expectType<typeof x>(z)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Currently you cannot use the postgrest-js to add additional headers which however is required in use-cases such as described in https://supabase.com/docs/guides/api/securing-your-api?queryGroups=database-method&database-method=sql&queryGroups=pre-request&pre-request=rate-limit-per-ip 

## What is the new behavior?

One can pass `additionalHeaders` and does not have to build a custom wrapper.
