### PR TITLE
Re-exports GetResult and Generic helpers to type Postgrest Queries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,3 +29,6 @@ export type {
   PostgrestSingleResponse,
   PostgrestMaybeSingleResponse,
 } from './types'
+// https://github.com/supabase/postgrest-js/issues/551
+// To be replaced with a helper type that only uses public types
+export type { GetResult as UnstableGetResult } from './select-query-parser/result'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Hi all! This PR simply re-exports a couple helper types that many of us were using to strongly type our query responses

Please let me know if I can help improve this!

## What is the current behavior?

Ever since 1.15.6, these types had been removed, they were internal but recent discussion is that these should be re-exposed

It used to be

```
import { GenericSchema, GenericTable } from "@supabase/postgrest-js/dist/module/types";
import { GetResult } from "@supabase/postgrest-js/dist/module/select-query-parser";
```

Please link any relevant issues here.

See #551 

## What is the new behavior?

It is now:

```
import { GetResult, GenericSchema, GenericTable } from "@supabase/postgrest-js";
```

In order to do something like the following:

```
type Collection = SelectPublic<"Collection", "id,imageObjectId,type,name,workspaceId">
```

We can build a helper type like this:

```
export type SchemaKeyType = keyof DB;
export type DatabaseTableKeyType = keyof DB["public"]["Tables"];
type RawSelect<
    SchemaName extends SchemaKeyType,
    TableName extends DatabaseTableKeyType,
    Query extends string = "*",
    Schema extends GenericSchema = DB[SchemaName],
    Table extends GenericTable = Schema["Tables"][TableName],
    Relationships = Table extends { Relationships: infer R } ? R : unknown
> = GetResult<Schema, Table["Row"], TableName, Relationships, Query>;

export type SelectPublic<Table extends DatabaseTableKeyType, Query extends string = "*"> = RawSelect<"public", Table, Query>;
```

In order to do this we need access to: `GetResult`, `GenericSchema`, and `GenericTable`

So I've simply exported those from their respective files.

Now we get our get our types back :~)

<img width="632" alt="image" src="https://github.com/user-attachments/assets/4e9b929b-e0b6-4234-a932-2bdb40347574">
