### PR TITLE
Use class PostgrestError instead of type PostgrestError, remove type PostgrestError

### DIFF
--- a/src/PostgrestError.ts
+++ b/src/PostgrestError.ts
@@ -1,11 +1,14 @@
-import type { PostgrestError as IPostgrestError } from './types'
-
-export default class PostgrestError extends Error implements IPostgrestError {
+/**
+ * Error format
+ *
+ * {@link https://postgrest.org/en/stable/api.html?highlight=options#errors-and-http-status-codes}
+ */
+export default class PostgrestError extends Error {
   details: string
   hint: string
   code: string
 
-  constructor(context: IPostgrestError) {
+  constructor(context: { message: string; details: string; hint: string; code: string }) {
     super(context.message)
     this.name = 'PostgrestError'
     this.details = context.details

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,6 @@
-export type Fetch = typeof fetch
+import PostgrestError from './PostgrestError'
 
-/**
- * Error format
- *
- * {@link https://postgrest.org/en/stable/api.html?highlight=options#errors-and-http-status-codes}
- */
-export type PostgrestError = {
-  message: string
-  details: string
-  hint: string
-  code: string
-}
+export type Fetch = typeof fetch
 
 /**
  * Response format


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes
> Type `PostgrestError` is not assignable to type `PostgrestError`.

## What is the current behavior?

Type `PostgrestError`and class `PostgrestError` are not compatible

## What is the new behavior?

Use class `PostgrestError` instead of type `PostgrestError`, remove type `PostgrestError`

## Additional context

https://github.com/supabase/postgrest-js/issues/561
