### PR TITLE
fix(types): select query error results and !inner whitespaces

### DIFF
--- a/src/select-query-parser/parser.ts
+++ b/src/select-query-parser/parser.ts
@@ -98,14 +98,14 @@ type ParseField<Input extends string> = Input extends ''
   ? Name extends 'count'
     ? ParseCountField<Input>
     : Remainder extends `!inner${infer Remainder}`
-    ? ParseEmbeddedResource<Remainder> extends [
+    ? ParseEmbeddedResource<EatWhitespace<Remainder>> extends [
         infer Children extends Ast.Node[],
         `${infer Remainder}`
       ]
       ? // `field!inner(nodes)`
         [{ type: 'field'; name: Name; innerJoin: true; children: Children }, Remainder]
       : CreateParserErrorIfRequired<
-          ParseEmbeddedResource<Remainder>,
+          ParseEmbeddedResource<EatWhitespace<Remainder>>,
           `Expected embedded resource after "!inner" at \`${Remainder}\``
         >
     : EatWhitespace<Remainder> extends `!left${infer Remainder}`

--- a/src/select-query-parser/result.ts
+++ b/src/select-query-parser/result.ts
@@ -16,6 +16,7 @@ import {
   IsRelationNullable,
   ResolveRelationship,
   SelectQueryError,
+  UnwrapErrorMessages,
 } from './utils'
 
 /**
@@ -35,16 +36,18 @@ export type GetResult<
   Query extends string
 > = Relationships extends null // For .rpc calls the passed relationships will be null in that case, the result will always be the function return type
   ? ParseQuery<Query> extends infer ParsedQuery extends Ast.Node[]
-    ? RPCCallNodes<ParsedQuery, RelationName extends string ? RelationName : 'rpc_call', Row>
+    ? UnwrapErrorMessages<
+        RPCCallNodes<ParsedQuery, RelationName extends string ? RelationName : 'rpc_call', Row>
+      >
     : Row
   : ParseQuery<Query> extends infer ParsedQuery
   ? ParsedQuery extends Ast.Node[]
     ? RelationName extends string
       ? Relationships extends GenericRelationship[]
-        ? ProcessNodes<Schema, Row, RelationName, Relationships, ParsedQuery>
-        : SelectQueryError<'Invalid Relationships cannot infer result type'>
-      : SelectQueryError<'Invalid RelationName cannot infer result type'>
-    : ParsedQuery
+        ? UnwrapErrorMessages<ProcessNodes<Schema, Row, RelationName, Relationships, ParsedQuery>>
+        : UnwrapErrorMessages<SelectQueryError<'Invalid Relationships cannot infer result type'>>
+      : UnwrapErrorMessages<SelectQueryError<'Invalid RelationName cannot infer result type'>>
+    : UnwrapErrorMessages<ParsedQuery>
   : never
 
 /**

--- a/src/select-query-parser/utils.ts
+++ b/src/select-query-parser/utils.ts
@@ -10,6 +10,12 @@ import {
   UnionToArray,
 } from './types'
 
+export type UnwrapErrorMessages<T> = T extends SelectQueryError<infer M>
+  ? M
+  : T extends Record<string, unknown>
+  ? { [K in keyof T]: UnwrapErrorMessages<T[K]> }
+  : T
+
 export type SelectQueryError<Message extends string> = { error: true } & Message
 
 type RequireHintingSelectQueryError<

--- a/src/select-query-parser/utils.ts
+++ b/src/select-query-parser/utils.ts
@@ -10,18 +10,22 @@ import {
   UnionToArray,
 } from './types'
 
-export type UnwrapErrorMessages<T> = T extends SelectQueryError<infer M>
-  ? M
-  : T extends Record<string, unknown>
-  ? { [K in keyof T]: UnwrapErrorMessages<T[K]> }
-  : T
-
 export type SelectQueryError<Message extends string> = { error: true } & Message
 
 type RequireHintingSelectQueryError<
   DistantName extends string,
   RelationName extends string
 > = SelectQueryError<`Could not embed because more than one relationship was found for '${DistantName}' and '${RelationName}' you need to hint the column with ${DistantName}!<columnName> ?`>
+
+export type UnwrapErrorMessages<T> = T extends SelectQueryError<infer M>
+  ? M
+  : T extends SelectQueryError<infer M>[]
+  ? M[]
+  : T extends (infer U)[]
+  ? UnwrapErrorMessages<U>[]
+  : T extends Record<string, unknown>
+  ? { [K in keyof T]: UnwrapErrorMessages<T[K]> }
+  : T
 
 export type GetFieldNodeResultName<Field extends Ast.FieldNode> = Field['alias'] extends string
   ? Field['alias']

--- a/test/select-query-parser/parser.test-d.ts
+++ b/test/select-query-parser/parser.test-d.ts
@@ -493,6 +493,56 @@ import { selectParams } from '../relationships'
   ])
 }
 
+// many-to-one join
+{
+  expectType<ParseQuery<'message, channels (slug)'>>([
+    { type: 'field', name: 'message' },
+    {
+      type: 'field',
+      name: 'channels',
+      children: [{ type: 'field', name: 'slug' }],
+    },
+  ])
+}
+
+// many-to-one join with inner
+{
+  expectType<ParseQuery<'message, channels!inner (slug)'>>([
+    { type: 'field', name: 'message' },
+    {
+      type: 'field',
+      name: 'channels',
+      innerJoin: true,
+      children: [{ type: 'field', name: 'slug' }],
+    },
+  ])
+}
+
+// many-to-one join with not null
+{
+  expectType<ParseQuery<'message, channels (slug)'>>([
+    { type: 'field', name: 'message' },
+    {
+      type: 'field',
+      name: 'channels',
+      children: [{ type: 'field', name: 'slug' }],
+    },
+  ])
+}
+
+// many-to-one join with inner and not null
+{
+  expectType<ParseQuery<'message, channels!inner (slug)'>>([
+    { type: 'field', name: 'message' },
+    {
+      type: 'field',
+      name: 'channels',
+      innerJoin: true,
+      children: [{ type: 'field', name: 'slug' }],
+    },
+  ])
+}
+
 // ParserError test cases
 // Empty string
 {

--- a/test/select-query-parser/select.test-d.ts
+++ b/test/select-query-parser/select.test-d.ts
@@ -1,7 +1,6 @@
 import { expectType } from 'tsd'
 import { TypeEqual } from 'ts-expect'
 import { Json } from '../../src/select-query-parser/types'
-import { SelectQueryError } from '../../src/select-query-parser/utils'
 import { Prettify } from '../../src/types'
 import { Database } from '../types'
 import { selectQueries } from '../relationships'
@@ -271,7 +270,7 @@ type Schema = Database['public']
       id: number
       second_user: string
       third_wheel: string | null
-      first_user: SelectQueryError<"Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?">
+      first_user: "Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?"
     }>
     second_friend_of: Array<Database['public']['Tables']['best_friends']['Row']>
     third_wheel_of: Array<Database['public']['Tables']['best_friends']['Row']>
@@ -440,7 +439,7 @@ type Schema = Database['public']
   let result: Exclude<typeof data, null>
   let expected: {
     username: string
-    messages: SelectQueryError<"column 'sum' does not exist on 'messages'.">[]
+    messages: "column 'sum' does not exist on 'messages'."[]
   }
   expectType<TypeEqual<typeof result, typeof expected>>(true)
 }

--- a/test/select-query-parser/select.test-d.ts
+++ b/test/select-query-parser/select.test-d.ts
@@ -198,9 +198,9 @@ type Schema = Database['public']
   const { data } = await selectQueries.joinOneToOneWithNullablesNoHint.limit(1).single()
   let result: Exclude<typeof data, null>
   let expected: {
-    first_user: SelectQueryError<"Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?">
-    second_user: SelectQueryError<"Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?">
-    third_wheel: SelectQueryError<"Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?">
+    first_user: "Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?"
+    second_user: "Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?"
+    third_wheel: "Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?"
   }
   expectType<TypeEqual<typeof result, typeof expected>>(true)
 }
@@ -222,9 +222,9 @@ type Schema = Database['public']
   const { data } = await selectQueries.joinOneToManyWithNullablesNoHint.limit(1).single()
   let result: Exclude<typeof data, null>
   let expected: {
-    first_friend_of: SelectQueryError<"Could not embed because more than one relationship was found for 'best_friends' and 'users' you need to hint the column with best_friends!<columnName> ?">
-    second_friend_of: SelectQueryError<"Could not embed because more than one relationship was found for 'best_friends' and 'users' you need to hint the column with best_friends!<columnName> ?">
-    third_wheel_of: SelectQueryError<"Could not embed because more than one relationship was found for 'best_friends' and 'users' you need to hint the column with best_friends!<columnName> ?">
+    first_friend_of: "Could not embed because more than one relationship was found for 'best_friends' and 'users' you need to hint the column with best_friends!<columnName> ?"
+    second_friend_of: "Could not embed because more than one relationship was found for 'best_friends' and 'users' you need to hint the column with best_friends!<columnName> ?"
+    third_wheel_of: "Could not embed because more than one relationship was found for 'best_friends' and 'users' you need to hint the column with best_friends!<columnName> ?"
   }
   expectType<TypeEqual<typeof result, typeof expected>>(true)
 }
@@ -630,7 +630,7 @@ type Schema = Database['public']
   const { data } = await selectQueries.joinSelectViaColumnHintTwice.limit(1).single()
   let result: Exclude<typeof data, null>
   let expected: {
-    users: SelectQueryError<'table "best_friends" specified more than once use hinting for desambiguation'>
+    users: 'table "best_friends" specified more than once use hinting for desambiguation'
   }
   expectType<TypeEqual<typeof result, typeof expected>>(true)
 }
@@ -641,7 +641,7 @@ type Schema = Database['public']
   let result: Exclude<typeof data, null>
   let expected: {
     id: number
-    messages: SelectQueryError<'"channels" and "messages" do not form a many-to-one or one-to-one relationship spread not possible'>
+    messages: '"channels" and "messages" do not form a many-to-one or one-to-one relationship spread not possible'
   }
   expectType<TypeEqual<typeof result, typeof expected>>(true)
 }
@@ -684,7 +684,7 @@ type Schema = Database['public']
 {
   const { data } = await selectQueries.typecastingAndAggregate.limit(1).single()
   let result: Exclude<typeof data, null>
-  let expected: SelectQueryError<`column 'users' does not exist on 'messages'.`>
+  let expected: `column 'users' does not exist on 'messages'.`
   expectType<TypeEqual<typeof result, typeof expected>>(true)
 }
 
@@ -741,5 +741,5 @@ type Schema = Database['public']
 {
   const { data, error } = await selectQueries.aggregateOnMissingColumnWithAlias.limit(1).single()
   if (error) throw error
-  expectType<SelectQueryError<`column 'missing_column' does not exist on 'users'.`>>(data)
+  expectType<`column 'missing_column' does not exist on 'users'.`>(data)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Fix a bug where !inner contained whitespace before embedding
- Fix a bug where the user facing error would be a nested type [cf](https://github.com/supabase/supabase-js/issues/943#issuecomment-2428602323) unwrap it into a plain string in the final result instead.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
