### PR TITLE
fix(parser): revert error unwrapping

### DIFF
--- a/src/select-query-parser/result.ts
+++ b/src/select-query-parser/result.ts
@@ -16,7 +16,6 @@ import {
   IsRelationNullable,
   ResolveRelationship,
   SelectQueryError,
-  UnwrapErrorMessages,
 } from './utils'
 
 /**
@@ -36,18 +35,16 @@ export type GetResult<
   Query extends string
 > = Relationships extends null // For .rpc calls the passed relationships will be null in that case, the result will always be the function return type
   ? ParseQuery<Query> extends infer ParsedQuery extends Ast.Node[]
-    ? UnwrapErrorMessages<
-        RPCCallNodes<ParsedQuery, RelationName extends string ? RelationName : 'rpc_call', Row>
-      >
+    ? RPCCallNodes<ParsedQuery, RelationName extends string ? RelationName : 'rpc_call', Row>
     : Row
   : ParseQuery<Query> extends infer ParsedQuery
   ? ParsedQuery extends Ast.Node[]
     ? RelationName extends string
       ? Relationships extends GenericRelationship[]
-        ? UnwrapErrorMessages<ProcessNodes<Schema, Row, RelationName, Relationships, ParsedQuery>>
-        : UnwrapErrorMessages<SelectQueryError<'Invalid Relationships cannot infer result type'>>
-      : UnwrapErrorMessages<SelectQueryError<'Invalid RelationName cannot infer result type'>>
-    : UnwrapErrorMessages<ParsedQuery>
+        ? ProcessNodes<Schema, Row, RelationName, Relationships, ParsedQuery>
+        : SelectQueryError<'Invalid Relationships cannot infer result type'>
+      : SelectQueryError<'Invalid RelationName cannot infer result type'>
+    : ParsedQuery
   : never
 
 /**

--- a/src/select-query-parser/utils.ts
+++ b/src/select-query-parser/utils.ts
@@ -10,12 +10,6 @@ import {
   UnionToArray,
 } from './types'
 
-export type UnwrapErrorMessages<T> = T extends SelectQueryError<infer M>
-  ? M
-  : T extends Record<string, unknown>
-  ? { [K in keyof T]: UnwrapErrorMessages<T[K]> }
-  : T
-
 export type SelectQueryError<Message extends string> = { error: true } & Message
 
 type RequireHintingSelectQueryError<

--- a/src/select-query-parser/utils.ts
+++ b/src/select-query-parser/utils.ts
@@ -10,22 +10,18 @@ import {
   UnionToArray,
 } from './types'
 
+export type UnwrapErrorMessages<T> = T extends SelectQueryError<infer M>
+  ? M
+  : T extends Record<string, unknown>
+  ? { [K in keyof T]: UnwrapErrorMessages<T[K]> }
+  : T
+
 export type SelectQueryError<Message extends string> = { error: true } & Message
 
 type RequireHintingSelectQueryError<
   DistantName extends string,
   RelationName extends string
 > = SelectQueryError<`Could not embed because more than one relationship was found for '${DistantName}' and '${RelationName}' you need to hint the column with ${DistantName}!<columnName> ?`>
-
-export type UnwrapErrorMessages<T> = T extends SelectQueryError<infer M>
-  ? M
-  : T extends SelectQueryError<infer M>[]
-  ? M[]
-  : T extends (infer U)[]
-  ? UnwrapErrorMessages<U>[]
-  : T extends Record<string, unknown>
-  ? { [K in keyof T]: UnwrapErrorMessages<T[K]> }
-  : T
 
 export type GetFieldNodeResultName<Field extends Ast.FieldNode> = Field['alias'] extends string
   ? Field['alias']

--- a/src/select-query-parser/utils.ts
+++ b/src/select-query-parser/utils.ts
@@ -12,11 +12,6 @@ import {
 
 export type SelectQueryError<Message extends string> = { error: true } & Message
 
-type RequireHintingSelectQueryError<
-  DistantName extends string,
-  RelationName extends string
-> = SelectQueryError<`Could not embed because more than one relationship was found for '${DistantName}' and '${RelationName}' you need to hint the column with ${DistantName}!<columnName> ?`>
-
 export type GetFieldNodeResultName<Field extends Ast.FieldNode> = Field['alias'] extends string
   ? Field['alias']
   : Field['aggregateFunction'] extends AggregateFunctions
@@ -151,7 +146,7 @@ type HasMultipleFKeysToFRel<FRelName, Relationships> = Relationships extends [
 type CheckRelationshipError<
   Schema extends GenericSchema,
   Relationships extends GenericRelationship[],
-  CurrentTableOrView extends keyof TablesAndViews<Schema>,
+  CurrentTableOrView extends keyof TablesAndViews<Schema> & string,
   FoundRelation
 > = FoundRelation extends SelectQueryError<string>
   ? FoundRelation
@@ -166,10 +161,7 @@ type CheckRelationshipError<
   ? // We check if there is possible confusion with other relations with this table
     HasMultipleFKeysToFRel<RelatedRelationName, Relationships> extends true
     ? // If there is, postgrest will fail at runtime, and require desambiguation via hinting
-      RequireHintingSelectQueryError<
-        RelatedRelationName,
-        CurrentTableOrView extends string ? CurrentTableOrView : 'unknown'
-      >
+      SelectQueryError<`Could not embed because more than one relationship was found for '${RelatedRelationName}' and '${CurrentTableOrView}' you need to hint the column with ${RelatedRelationName}!<columnName> ?`>
     : FoundRelation
   : // Same check for forward relationships, but we must gather the relationships from the found relation
   FoundRelation extends {
@@ -178,13 +170,13 @@ type CheckRelationshipError<
         name: string
       }
       direction: 'forward'
-      from: infer From extends keyof TablesAndViews<Schema>
+      from: infer From extends keyof TablesAndViews<Schema> & string
     }
   ? HasMultipleFKeysToFRel<
       RelatedRelationName,
       TablesAndViews<Schema>[From]['Relationships']
     > extends true
-    ? RequireHintingSelectQueryError<From extends string ? From : 'unknown', RelatedRelationName>
+    ? SelectQueryError<`Could not embed because more than one relationship was found for '${From}' and '${RelatedRelationName}' you need to hint the column with ${From}!<columnName> ?`>
     : FoundRelation
   : FoundRelation
 
@@ -219,7 +211,7 @@ type ResolveReverseRelationship<
   Schema extends GenericSchema,
   Relationships extends GenericRelationship[],
   Field extends Ast.FieldNode,
-  CurrentTableOrView extends keyof TablesAndViews<Schema>
+  CurrentTableOrView extends keyof TablesAndViews<Schema> & string
 > = FindFieldMatchingRelationships<Schema, Relationships, Field> extends infer FoundRelation
   ? FoundRelation extends never
     ? false
@@ -235,10 +227,7 @@ type ResolveReverseRelationship<
           }
         : // If the relation was found via implicit relation naming, we must ensure there is no conflicting matches
         HasMultipleFKeysToFRel<RelatedRelationName, Relationships> extends true
-        ? RequireHintingSelectQueryError<
-            RelatedRelationName,
-            CurrentTableOrView extends string ? CurrentTableOrView : 'unknown'
-          >
+        ? SelectQueryError<`Could not embed because more than one relationship was found for '${RelatedRelationName}' and '${CurrentTableOrView}' you need to hint the column with ${RelatedRelationName}!<columnName> ?`>
         : {
             referencedTable: TablesAndViews<Schema>[RelatedRelationName]
             relation: FoundRelation

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -99,7 +99,7 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   }
   // getting this w/o the cast, not sure why:
   // Parameter type Json is declared too wide for argument type Json
-  expectType<Json>(data.bar as Json)
+  expectType<Json>(data.bar)
   expectType<string>(data.baz)
 }
 

--- a/test/select-query-parser/select.test-d.ts
+++ b/test/select-query-parser/select.test-d.ts
@@ -198,9 +198,9 @@ type Schema = Database['public']
   const { data } = await selectQueries.joinOneToOneWithNullablesNoHint.limit(1).single()
   let result: Exclude<typeof data, null>
   let expected: {
-    first_user: "Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?"
-    second_user: "Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?"
-    third_wheel: "Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?"
+    first_user: SelectQueryError<"Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?">
+    second_user: SelectQueryError<"Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?">
+    third_wheel: SelectQueryError<"Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?">
   }
   expectType<TypeEqual<typeof result, typeof expected>>(true)
 }
@@ -222,9 +222,9 @@ type Schema = Database['public']
   const { data } = await selectQueries.joinOneToManyWithNullablesNoHint.limit(1).single()
   let result: Exclude<typeof data, null>
   let expected: {
-    first_friend_of: "Could not embed because more than one relationship was found for 'best_friends' and 'users' you need to hint the column with best_friends!<columnName> ?"
-    second_friend_of: "Could not embed because more than one relationship was found for 'best_friends' and 'users' you need to hint the column with best_friends!<columnName> ?"
-    third_wheel_of: "Could not embed because more than one relationship was found for 'best_friends' and 'users' you need to hint the column with best_friends!<columnName> ?"
+    first_friend_of: SelectQueryError<"Could not embed because more than one relationship was found for 'best_friends' and 'users' you need to hint the column with best_friends!<columnName> ?">
+    second_friend_of: SelectQueryError<"Could not embed because more than one relationship was found for 'best_friends' and 'users' you need to hint the column with best_friends!<columnName> ?">
+    third_wheel_of: SelectQueryError<"Could not embed because more than one relationship was found for 'best_friends' and 'users' you need to hint the column with best_friends!<columnName> ?">
   }
   expectType<TypeEqual<typeof result, typeof expected>>(true)
 }
@@ -630,7 +630,7 @@ type Schema = Database['public']
   const { data } = await selectQueries.joinSelectViaColumnHintTwice.limit(1).single()
   let result: Exclude<typeof data, null>
   let expected: {
-    users: 'table "best_friends" specified more than once use hinting for desambiguation'
+    users: SelectQueryError<'table "best_friends" specified more than once use hinting for desambiguation'>
   }
   expectType<TypeEqual<typeof result, typeof expected>>(true)
 }
@@ -641,7 +641,7 @@ type Schema = Database['public']
   let result: Exclude<typeof data, null>
   let expected: {
     id: number
-    messages: '"channels" and "messages" do not form a many-to-one or one-to-one relationship spread not possible'
+    messages: SelectQueryError<'"channels" and "messages" do not form a many-to-one or one-to-one relationship spread not possible'>
   }
   expectType<TypeEqual<typeof result, typeof expected>>(true)
 }
@@ -684,7 +684,7 @@ type Schema = Database['public']
 {
   const { data } = await selectQueries.typecastingAndAggregate.limit(1).single()
   let result: Exclude<typeof data, null>
-  let expected: `column 'users' does not exist on 'messages'.`
+  let expected: SelectQueryError<`column 'users' does not exist on 'messages'.`>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
 }
 
@@ -741,7 +741,7 @@ type Schema = Database['public']
 {
   const { data, error } = await selectQueries.aggregateOnMissingColumnWithAlias.limit(1).single()
   if (error) throw error
-  expectType<`column 'missing_column' does not exist on 'users'.`>(data)
+  expectType<SelectQueryError<`column 'missing_column' does not exist on 'users'.`>>(data)
 }
 
 // many-to-many with join table

--- a/test/select-query-parser/select.test-d.ts
+++ b/test/select-query-parser/select.test-d.ts
@@ -1,6 +1,7 @@
 import { expectType } from 'tsd'
 import { TypeEqual } from 'ts-expect'
 import { Json } from '../../src/select-query-parser/types'
+import { SelectQueryError } from '../../src/select-query-parser/utils'
 import { Prettify } from '../../src/types'
 import { Database } from '../types'
 import { selectQueries } from '../relationships'
@@ -270,7 +271,7 @@ type Schema = Database['public']
       id: number
       second_user: string
       third_wheel: string | null
-      first_user: "Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?"
+      first_user: SelectQueryError<"Could not embed because more than one relationship was found for 'users' and 'best_friends' you need to hint the column with users!<columnName> ?">
     }>
     second_friend_of: Array<Database['public']['Tables']['best_friends']['Row']>
     third_wheel_of: Array<Database['public']['Tables']['best_friends']['Row']>
@@ -439,7 +440,7 @@ type Schema = Database['public']
   let result: Exclude<typeof data, null>
   let expected: {
     username: string
-    messages: "column 'sum' does not exist on 'messages'."[]
+    messages: SelectQueryError<"column 'sum' does not exist on 'messages'.">[]
   }
   expectType<TypeEqual<typeof result, typeof expected>>(true)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Revert the change made here: https://github.com/supabase/postgrest-js/pull/564

As the unwrapping of the errors introduced an issue with the final result type making the `Json` fields unwrapped as well.

So we'll still have some errors with `SelectQueryError<...>` and the user will sometimes need to access the property in error to get the full error message `result.field.errorField` but that's the lesser evil.

Also removed the `RequiredHint` type as it wasn't flattened in the end result anymore and TS would show it templated like so `RequireHintingSelectQueryError<'table', 'relationsName'>` instead of the plain error message. Use directly `SelectQueryError` instead.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
