### PR TITLE
fix(types): types result with schema as any

### DIFF
--- a/src/select-query-parser/utils.ts
+++ b/src/select-query-parser/utils.ts
@@ -10,6 +10,8 @@ import {
   UnionToArray,
 } from './types'
 
+export type IsAny<T> = 0 extends 1 & T ? true : false
+
 export type SelectQueryError<Message extends string> = { error: true } & Message
 
 export type GetFieldNodeResultName<Field extends Ast.FieldNode> = Field['alias'] extends string

--- a/test/select-query-parser/default-inference-d.ts
+++ b/test/select-query-parser/default-inference-d.ts
@@ -1,0 +1,96 @@
+import { PostgrestClient } from '../../src/index'
+import { expectType } from 'tsd'
+import { TypeEqual } from 'ts-expect'
+
+const REST_URL = 'http://localhost:3000'
+
+// Check for PostgrestClient without types provided to the client
+// basic embeding
+{
+  const postgrest = new PostgrestClient(REST_URL)
+  const { data } = await postgrest
+    .from('user_profile')
+    .select(
+      'user_id, some_embed(*), another_embed(first_field, second_field, renamed:field), aninnerembed!inner(id, name)'
+    )
+    .single()
+  let result: Exclude<typeof data, null>
+  let expected: {
+    user_id: any
+    some_embed: any[]
+    another_embed: {
+      first_field: any
+      second_field: any
+      renamed: any
+    }[]
+    aninnerembed: {
+      id: any
+      name: any
+    }[]
+  }
+  expectType<TypeEqual<typeof result, typeof expected>>(true)
+}
+// spread operator with stars should return any
+{
+  const postgrest = new PostgrestClient(REST_URL)
+  const { data } = await postgrest
+    .from('user_profile')
+    .select('user_id, some_embed(*), ...spreadstars(*)')
+    .single()
+  let result: Exclude<typeof data, null>
+  let expected: any
+  expectType<TypeEqual<typeof result, typeof expected>>(true)
+}
+// nested spread operator with stars should return any
+{
+  const postgrest = new PostgrestClient(REST_URL)
+  const { data } = await postgrest
+    .from('user_profile')
+    .select('user_id, some_embed(*), some_other(id, ...spreadstars(*))')
+    .single()
+  let result: Exclude<typeof data, null>
+  let expected: {
+    user_id: any
+    some_embed: any[]
+    some_other: any[]
+  }
+  expectType<TypeEqual<typeof result, typeof expected>>(true)
+}
+// rpc without types should raise similar results
+{
+  const postgrest = new PostgrestClient(REST_URL)
+  const { data } = await postgrest.rpc('user_profile').select('user_id, some_embed(*)').single()
+  let result: Exclude<typeof data, null>
+  let expected: {
+    user_id: any
+    some_embed: any[]
+  }
+  expectType<TypeEqual<typeof result, typeof expected>>(true)
+}
+// check for nested operators
+{
+  const postgrest = new PostgrestClient(REST_URL)
+  const { data } = await postgrest
+    .from('user_profile')
+    .select(
+      'user_id, some_embed(*), another_embed(first_field, second_field, renamed:field), aninnerembed!inner(id, name), ...spreadwithfields(field_spread, another)'
+    )
+    .single()
+  let result: Exclude<typeof data, null>
+  let expected: {
+    user_id: any
+    some_embed: any[]
+    another_embed: {
+      first_field: any
+      second_field: any
+      renamed: any
+    }[]
+    aninnerembed: {
+      id: any
+      name: any
+    }[]
+    field_spread: any
+    another: any
+  }
+  expectType<TypeEqual<typeof result, typeof expected>>(true)
+}

--- a/test/select-query-parser/default-inference-d.ts
+++ b/test/select-query-parser/default-inference-d.ts
@@ -5,6 +5,11 @@ import { TypeEqual } from 'ts-expect'
 const REST_URL = 'http://localhost:3000'
 
 // Check for PostgrestClient without types provided to the client
+{
+  const postgrest = new PostgrestClient(REST_URL)
+  const { data } = await postgrest.from('user_profile').select()
+  expectType<TypeEqual<typeof data, any[] | null>>(true)
+}
 // basic embeding
 {
   const postgrest = new PostgrestClient(REST_URL)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the regression in the types inferences if the client is called without a valid schema and defaulted to any

Context: https://discord.com/channels/839993398554656828/1300816893682126912/1301172995326476288

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
