### PR TITLE
fix(types): add deduplication helpers for retro-compatibility

### DIFF
--- a/test/select-query-parser/types.test-d.ts
+++ b/test/select-query-parser/types.test-d.ts
@@ -1,0 +1,55 @@
+import { expectType } from 'tsd'
+import { TypeEqual } from 'ts-expect'
+import { DeduplicateRelationships } from '../../src/select-query-parser/utils'
+// Deduplicate exact sames relationships
+{
+  type rels = [
+    {
+      foreignKeyName: 'test_fkey'
+      columns: ['project_id']
+      referencedRelation: 'project_subscriptions'
+      referencedColumns: ['project_id']
+    },
+    {
+      foreignKeyName: 'test_fkey'
+      columns: ['project_id']
+      referencedRelation: 'projects'
+      referencedColumns: ['id']
+    },
+    {
+      foreignKeyName: 'test_fkey'
+      columns: ['project_id']
+      referencedRelation: 'projects'
+      referencedColumns: ['id']
+    },
+    {
+      foreignKeyName: 'test_fkey'
+      columns: ['project_id']
+      referencedRelation: 'sls_physical_backups_monitoring'
+      referencedColumns: ['project_id']
+    }
+  ]
+  type expected = [
+    {
+      foreignKeyName: 'test_fkey'
+      columns: ['project_id']
+      referencedRelation: 'project_subscriptions'
+      referencedColumns: ['project_id']
+    },
+    {
+      foreignKeyName: 'test_fkey'
+      columns: ['project_id']
+      referencedRelation: 'projects'
+      referencedColumns: ['id']
+    },
+    {
+      foreignKeyName: 'test_fkey'
+      columns: ['project_id']
+      referencedRelation: 'sls_physical_backups_monitoring'
+      referencedColumns: ['project_id']
+    }
+  ]
+
+  type result = DeduplicateRelationships<rels>
+  expectType<TypeEqual<result, expected>>(true)
+}

--- a/test/types.ts
+++ b/test/types.ts
@@ -87,6 +87,13 @@ export type Database = {
             referencedColumns: ['username']
           },
           {
+            foreignKeyName: 'best_friends_first_user_fkey'
+            columns: ['first_user']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['username']
+          },
+          {
             foreignKeyName: 'best_friends_second_user_fkey'
             columns: ['second_user']
             isOneToOne: false
@@ -108,6 +115,13 @@ export type Database = {
             referencedColumns: ['username']
           },
           {
+            foreignKeyName: 'best_friends_second_user_fkey'
+            columns: ['second_user']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['username']
+          },
+          {
             foreignKeyName: 'best_friends_third_wheel_fkey'
             columns: ['third_wheel']
             isOneToOne: false
@@ -119,6 +133,13 @@ export type Database = {
             columns: ['third_wheel']
             isOneToOne: false
             referencedRelation: 'updatable_view'
+            referencedColumns: ['username']
+          },
+          {
+            foreignKeyName: 'best_friends_third_wheel_fkey'
+            columns: ['third_wheel']
+            isOneToOne: false
+            referencedRelation: 'users'
             referencedColumns: ['username']
           },
           {
@@ -144,6 +165,13 @@ export type Database = {
           id?: number
         }
         Relationships: [
+          {
+            foreignKeyName: 'channel_details_id_fkey'
+            columns: ['id']
+            isOneToOne: true
+            referencedRelation: 'channels'
+            referencedColumns: ['id']
+          },
           {
             foreignKeyName: 'channel_details_id_fkey'
             columns: ['id']
@@ -194,6 +222,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: 'collections'
             referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'collections_parent_id_fkey'
+            columns: ['parent_id']
+            isOneToOne: false
+            referencedRelation: 'collections'
+            referencedColumns: ['id']
           }
         ]
       }
@@ -228,6 +263,13 @@ export type Database = {
             referencedColumns: ['id']
           },
           {
+            foreignKeyName: 'messages_channel_id_fkey'
+            columns: ['channel_id']
+            isOneToOne: false
+            referencedRelation: 'channels'
+            referencedColumns: ['id']
+          },
+          {
             foreignKeyName: 'messages_username_fkey'
             columns: ['username']
             isOneToOne: false
@@ -239,6 +281,13 @@ export type Database = {
             columns: ['username']
             isOneToOne: false
             referencedRelation: 'updatable_view'
+            referencedColumns: ['username']
+          },
+          {
+            foreignKeyName: 'messages_username_fkey'
+            columns: ['username']
+            isOneToOne: false
+            referencedRelation: 'users'
             referencedColumns: ['username']
           },
           {
@@ -264,6 +313,20 @@ export type Database = {
           product_id?: number
         }
         Relationships: [
+          {
+            foreignKeyName: 'product_categories_category_id_fkey'
+            columns: ['category_id']
+            isOneToOne: false
+            referencedRelation: 'categories'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'product_categories_product_id_fkey'
+            columns: ['product_id']
+            isOneToOne: false
+            referencedRelation: 'products'
+            referencedColumns: ['id']
+          },
           {
             foreignKeyName: 'product_categories_category_id_fkey'
             columns: ['category_id']
@@ -387,6 +450,13 @@ export type Database = {
             columns: ['username']
             isOneToOne: false
             referencedRelation: 'updatable_view'
+            referencedColumns: ['username']
+          },
+          {
+            foreignKeyName: 'user_profiles_username_fkey'
+            columns: ['username']
+            isOneToOne: false
+            referencedRelation: 'users'
             referencedColumns: ['username']
           },
           {


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Re-introduce deduplication logic for relationships https://github.com/supabase/postgrest-js/pull/558#discussion_r1787643350 for retro-compatibility

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
