### PR TITLE
fix(types): inference for default any schema

### DIFF
--- a/src/select-query-parser/result.ts
+++ b/src/select-query-parser/result.ts
@@ -78,15 +78,9 @@ type ProcessFieldNodeWithoutSchema<Node extends Ast.FieldNode> = IsNonEmptyArray
   Node['children']
 > extends true
   ? {
-      [K in Node['name']]: Node['children'] extends Ast.StarNode[]
-        ? any[]
-        : Node['children'] extends Ast.FieldNode[]
-        ? {
-            [P in Node['children'][number] as GetFieldNodeResultName<P>]: P['castType'] extends PostgreSQLTypes
-              ? TypeScriptTypes<P['castType']>
-              : any
-          }[]
-        : any[]
+      [K in GetFieldNodeResultName<Node>]: Node['children'] extends Ast.Node[]
+        ? ProcessNodesWithoutSchema<Node['children']>[]
+        : ProcessSimpleFieldWithoutSchema<Node>
     }
   : ProcessSimpleFieldWithoutSchema<Node>
 

--- a/test/select-query-parser/default-inference-d.ts
+++ b/test/select-query-parser/default-inference-d.ts
@@ -35,6 +35,22 @@ const REST_URL = 'http://localhost:3000'
   }
   expectType<TypeEqual<typeof result, typeof expected>>(true)
 }
+// embeding renaming
+{
+  const postgrest = new PostgrestClient(REST_URL)
+  const { data } = await postgrest
+    .from('projects')
+    .select('status,service:services(service_api_keys(*))')
+    .single()
+  let result: Exclude<typeof data, null>
+  let expected: {
+    status: any
+    service: {
+      service_api_keys: any[]
+    }[]
+  }
+  expectType<TypeEqual<typeof result, typeof expected>>(true)
+}
 // spread operator with stars should return any
 {
   const postgrest = new PostgrestClient(REST_URL)


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Detected a bug for the "any" schema case while upgrading the workers dependency this make the inference logic more recursive reducing the chances of error and restore the type to match what was generated on `2.46.1`

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
