### PR TITLE
fix: Add missing PostgrestError export to wrapper.mjs

### DIFF
--- a/wrapper.mjs
+++ b/wrapper.mjs
@@ -5,6 +5,7 @@ const {
   PostgrestFilterBuilder,
   PostgrestTransformBuilder,
   PostgrestBuilder,
+  PostgrestError,
 } = index
 
 export {
@@ -13,6 +14,7 @@ export {
   PostgrestFilterBuilder,
   PostgrestQueryBuilder,
   PostgrestTransformBuilder,
+  PostgrestError,
 }
 
 // compatibility with CJS output
@@ -22,4 +24,5 @@ export default {
   PostgrestFilterBuilder,
   PostgrestTransformBuilder,
   PostgrestBuilder,
+  PostgrestError,
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

As per title

## What is the current behavior?

`PostgrestError` is not properly exported

## What is the new behavior?

`PostgrestError` is properly exported
