### PR TITLE
fix: Correctly validate enum values in eq, neq and in methods

### DIFF
--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -32,11 +32,6 @@ export default class PostgrestFilterBuilder<
   RelationName = unknown,
   Relationships = unknown
 > extends PostgrestTransformBuilder<Schema, Row, Result, RelationName, Relationships> {
-  eq<ColumnName extends string & keyof Row>(
-    column: ColumnName,
-    value: NonNullable<Row[ColumnName]>
-  ): this
-  eq<Value extends unknown>(column: string, value: NonNullable<Value>): this
   /**
    * Match only rows where `column` is equal to `value`.
    *
@@ -45,20 +40,24 @@ export default class PostgrestFilterBuilder<
    * @param column - The column to filter on
    * @param value - The value to filter with
    */
-  eq(column: string, value: unknown): this {
+  eq<ColumnName extends string>(
+    column: ColumnName,
+    value: ColumnName extends keyof Row ? NonNullable<Row[ColumnName]> : NonNullable<unknown>
+  ): this {
     this.url.searchParams.append(column, `eq.${value}`)
     return this
   }
 
-  neq<ColumnName extends string & keyof Row>(column: ColumnName, value: Row[ColumnName]): this
-  neq(column: string, value: unknown): this
   /**
    * Match only rows where `column` is not equal to `value`.
    *
    * @param column - The column to filter on
    * @param value - The value to filter with
    */
-  neq(column: string, value: unknown): this {
+  neq<ColumnName extends string>(
+    column: ColumnName,
+    value: ColumnName extends keyof Row ? Row[ColumnName] : unknown
+  ): this {
     this.url.searchParams.append(column, `neq.${value}`)
     return this
   }
@@ -227,18 +226,16 @@ export default class PostgrestFilterBuilder<
     return this
   }
 
-  in<ColumnName extends string & keyof Row>(
-    column: ColumnName,
-    values: ReadonlyArray<Row[ColumnName]>
-  ): this
-  in(column: string, values: readonly unknown[]): this
   /**
    * Match only rows where `column` is included in the `values` array.
    *
    * @param column - The column to filter on
    * @param values - The values array to filter with
    */
-  in(column: string, values: readonly unknown[]): this {
+  in<ColumnName extends string>(
+    column: ColumnName,
+    values: ColumnName extends keyof Row ? ReadonlyArray<Row[ColumnName]> : unknown[]
+  ): this {
     const cleanedValues = Array.from(new Set(values))
       .map((s) => {
         // handle postgrest reserved characters


### PR DESCRIPTION
I believe that when TypeScript resolves overloads, it squashes our 2 variants together, as they are not specific enough to be made distinct. I'm not exactly sure why it doesn't always favor the "more specific" type, but it is what it is.

Second overload can be squashed down into a single one, making overloads unnecessary at all and we can express the type definition directly in the implementation.

(we can also unify most if not all filters using this syntax, but it's your call and I didn't want to make this PR unnecessarily big)

Here's test playground for the issue:

https://www.typescriptlang.org/play/?ssl=15&ssc=1&pln=16&pc=1#code/PTAEFpNAhAlB5A0gUQHIFgBQWAuBPABwFNRYB7Ad1AF5QBvLUUASwBMAuUAZxwCdmAdgHMANI1C8yAGyKcA5AEEAIgFkAkqjmgAPqDkBVAMrJYcrAF8sWAGYBXAQGMczMgJZdyMgIq2ivPAA8AMLStgC2AqgAhmEkRAAeOEQCrFzcfIJCoABkoADWRHhk1qSUAHwAFOIOoRGcIVLhkTFEYphMAG5RjbKgqK6otlJSUQBGMgHkFADaDU3RsQC6ZVgAlJw8-MIA3Db2Ti5uzB7SRD5+gQBq3b6gCUkpafZ5ApQClTWNdelboqBdPU4-UiQxG4yIAWuPTK6x+mV2mDsjmcrncnjOvn8FU+TQ2GWEIn+N16z1eFAEsM2mXo1VcPG4RCivAcAAsAApMmJpWgCIhUfSwAAyhkZzPZnLCXAqq3EXFFrI5vC5ADoogRiClsbUBISAAa8gCOyoAJHQAb5zLqZe0JEQcLZeG45UyFRKuMqcGRDPihNKLFZMMd0ecsXJJDI5IS5BQWVEkh0-AB9ChkXh5Lhya1YEAQKAAMTUAA1kEoA-hiKB4DgWX4pjQaTa2Hjfm0mOHeopVBotLoDMZTP7sIj9iijidvJi8HnmPEiKxgtqFnFEslUnDhJVxEwcd85hEl62mETAaA981YncV498oVipXq7XKKAAPz3mu8KazRctRagTikt5KR9BttzpHAGRdcUlUleteX5IURUgxUuT9G1nTFZDJVVdVVy1L4dVAfUiCNU1zSIS1rTbO0HSdeUoJVT1vV+VDLCHINThDKcZznCow1OSM9BjOMiATXhk1TdNMywdiJwuadZ1YXj2wEzt1E0VYgA