### PR TITLE
fix(types): type result for throwOnError responses

### DIFF
--- a/src/PostgrestBuilder.ts
+++ b/src/PostgrestBuilder.ts
@@ -45,9 +45,9 @@ export default abstract class PostgrestBuilder<Result, ThrowOnError extends bool
    *
    * {@link https://github.com/supabase/supabase-js/issues/92}
    */
-  throwOnError(): PostgrestBuilder<Result, true> {
+  throwOnError(): this & PostgrestBuilder<Result, true> {
     this.shouldThrowOnError = true
-    return this as PostgrestBuilder<Result, true>
+    return this as this & PostgrestBuilder<Result, true>
   }
 
   /**

--- a/src/PostgrestBuilder.ts
+++ b/src/PostgrestBuilder.ts
@@ -1,21 +1,13 @@
 // @ts-ignore
 import nodeFetch from '@supabase/node-fetch'
 
-import type { Fetch } from './types'
+import type { Fetch, PostgrestSingleResponse, PostgrestResponseSuccess } from './types'
 import PostgrestError from './PostgrestError'
 
 export default abstract class PostgrestBuilder<Result, ThrowOnError extends boolean = false>
   implements
     PromiseLike<
-      ThrowOnError extends true
-        ? { data: Result; count: number | null; status: number; statusText: string }
-        : {
-            data: Result | null
-            error: PostgrestError | null
-            count: number | null
-            status: number
-            statusText: string
-          }
+      ThrowOnError extends true ? PostgrestResponseSuccess<Result> : PostgrestSingleResponse<Result>
     >
 {
   protected method: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE'
@@ -69,27 +61,15 @@ export default abstract class PostgrestBuilder<Result, ThrowOnError extends bool
 
   then<
     TResult1 = ThrowOnError extends true
-      ? { data: Result; count: number | null; status: number; statusText: string }
-      : {
-          data: Result | null
-          error: PostgrestError | null
-          count: number | null
-          status: number
-          statusText: string
-        },
+      ? PostgrestResponseSuccess<Result>
+      : PostgrestSingleResponse<Result>,
     TResult2 = never
   >(
     onfulfilled?:
       | ((
           value: ThrowOnError extends true
-            ? { data: Result; count: number | null; status: number; statusText: string }
-            : {
-                data: Result | null
-                error: PostgrestError | null
-                count: number | null
-                status: number
-                statusText: string
-              }
+            ? PostgrestResponseSuccess<Result>
+            : PostgrestSingleResponse<Result>
         ) => TResult1 | PromiseLike<TResult1>)
       | undefined
       | null,

--- a/src/PostgrestBuilder.ts
+++ b/src/PostgrestBuilder.ts
@@ -1,11 +1,22 @@
 // @ts-ignore
 import nodeFetch from '@supabase/node-fetch'
 
-import type { Fetch, PostgrestSingleResponse } from './types'
+import type { Fetch } from './types'
 import PostgrestError from './PostgrestError'
 
-export default abstract class PostgrestBuilder<Result>
-  implements PromiseLike<PostgrestSingleResponse<Result>>
+export default abstract class PostgrestBuilder<Result, ThrowOnError extends boolean = false>
+  implements
+    PromiseLike<
+      ThrowOnError extends true
+        ? { data: Result; count: number | null; status: number; statusText: string }
+        : {
+            data: Result | null
+            error: PostgrestError | null
+            count: number | null
+            status: number
+            statusText: string
+          }
+    >
 {
   protected method: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE'
   protected url: URL
@@ -42,9 +53,9 @@ export default abstract class PostgrestBuilder<Result>
    *
    * {@link https://github.com/supabase/supabase-js/issues/92}
    */
-  throwOnError(): this {
+  throwOnError(): PostgrestBuilder<Result, true> {
     this.shouldThrowOnError = true
-    return this
+    return this as PostgrestBuilder<Result, true>
   }
 
   /**
@@ -56,9 +67,30 @@ export default abstract class PostgrestBuilder<Result>
     return this
   }
 
-  then<TResult1 = PostgrestSingleResponse<Result>, TResult2 = never>(
+  then<
+    TResult1 = ThrowOnError extends true
+      ? { data: Result; count: number | null; status: number; statusText: string }
+      : {
+          data: Result | null
+          error: PostgrestError | null
+          count: number | null
+          status: number
+          statusText: string
+        },
+    TResult2 = never
+  >(
     onfulfilled?:
-      | ((value: PostgrestSingleResponse<Result>) => TResult1 | PromiseLike<TResult1>)
+      | ((
+          value: ThrowOnError extends true
+            ? { data: Result; count: number | null; status: number; statusText: string }
+            : {
+                data: Result | null
+                error: PostgrestError | null
+                count: number | null
+                status: number
+                statusText: string
+              }
+        ) => TResult1 | PromiseLike<TResult1>)
       | undefined
       | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null

--- a/src/PostgrestTransformBuilder.ts
+++ b/src/PostgrestTransformBuilder.ts
@@ -192,7 +192,7 @@ export default class PostgrestTransformBuilder<
     ResultOne = Result extends (infer ResultOne)[] ? ResultOne : never
   >(): PostgrestBuilder<ResultOne> {
     this.headers['Accept'] = 'application/vnd.pgrst.object+json'
-    return this as PostgrestBuilder<ResultOne>
+    return this as unknown as PostgrestBuilder<ResultOne>
   }
 
   /**
@@ -212,7 +212,7 @@ export default class PostgrestTransformBuilder<
       this.headers['Accept'] = 'application/vnd.pgrst.object+json'
     }
     this.isMaybeSingle = true
-    return this as PostgrestBuilder<ResultOne | null>
+    return this as unknown as PostgrestBuilder<ResultOne | null>
   }
 
   /**
@@ -220,7 +220,7 @@ export default class PostgrestTransformBuilder<
    */
   csv(): PostgrestBuilder<string> {
     this.headers['Accept'] = 'text/csv'
-    return this as PostgrestBuilder<string>
+    return this as unknown as PostgrestBuilder<string>
   }
 
   /**
@@ -228,7 +228,7 @@ export default class PostgrestTransformBuilder<
    */
   geojson(): PostgrestBuilder<Record<string, unknown>> {
     this.headers['Accept'] = 'application/geo+json'
-    return this as PostgrestBuilder<Record<string, unknown>>
+    return this as unknown as PostgrestBuilder<Record<string, unknown>>
   }
 
   /**
@@ -285,8 +285,8 @@ export default class PostgrestTransformBuilder<
     this.headers[
       'Accept'
     ] = `application/vnd.pgrst.plan+${format}; for="${forMediatype}"; options=${options};`
-    if (format === 'json') return this as PostgrestBuilder<Record<string, unknown>[]>
-    else return this as PostgrestBuilder<string>
+    if (format === 'json') return this as unknown as PostgrestBuilder<Record<string, unknown>[]>
+    else return this as unknown as PostgrestBuilder<string>
   }
 
   /**

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -209,8 +209,8 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   const x = postgrest.from('channels').select()
   const y = x.throwOnError()
   const z = x.setHeader('', '')
-  expectType<typeof x>(y)
-  expectType<typeof x>(z)
+  expectType<typeof y extends typeof x ? true : false>(true)
+  expectType<typeof z extends typeof x ? true : false>(true)
 }
 
 // Should have nullable data and error field
@@ -239,6 +239,29 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
     .select('username, messages(id, message)')
     .limit(1)
     .throwOnError()
+  const { data } = result
+  const { error } = result
+  let expected:
+    | {
+        username: string
+        messages: {
+          id: number
+          message: string | null
+        }[]
+      }[]
+  expectType<TypeEqual<typeof data, typeof expected>>(true)
+  expectType<TypeEqual<typeof error, null>>(true)
+  error
+}
+
+// Should work with throwOnError middle of the chaining
+{
+  const result = await postgrest
+    .from('users')
+    .select('username, messages(id, message)')
+    .throwOnError()
+    .eq('username', 'test')
+    .limit(1)
   const { data } = result
   const { error } = result
   let expected:

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -240,7 +240,6 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
     .limit(1)
     .throwOnError()
   const { data } = result
-  // @ts-expect-error error property does not exist when using throwOnError()
   const { error } = result
   let expected:
     | {
@@ -251,6 +250,6 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
         }[]
       }[]
   expectType<TypeEqual<typeof data, typeof expected>>(true)
-  // just here so our variable isn't unused
+  expectType<TypeEqual<typeof error, null>>(true)
   error
 }


### PR DESCRIPTION
When using throwOnError(), the response type is now more strictly typed:
- Data is guaranteed to be non-null
- Response type is controlled by generic ThrowOnError boolean parameter

Fixes #563 