### PR TITLE
feat(types): add json path type inference

### DIFF
--- a/src/select-query-parser/utils.ts
+++ b/src/select-query-parser/utils.ts
@@ -544,3 +544,11 @@ export type FindFieldMatchingRelationships<
       name: Field['name']
     }
   : SelectQueryError<'Failed to find matching relation via name'>
+
+export type JsonPathToAccessor<Path extends string> = Path extends `${infer P1}->${infer P2}`
+  ? P2 extends `>${infer Rest}` // Check if P2 starts with > (from ->>)
+    ? JsonPathToAccessor<`${P1}.${Rest}`>
+    : JsonPathToAccessor<`${P1}.${P2}`>
+  : Path extends `${infer P1}::${infer _}` // Handle type casting
+  ? JsonPathToAccessor<P1> // Process the path without the cast type
+  : Path

--- a/src/select-query-parser/utils.ts
+++ b/src/select-query-parser/utils.ts
@@ -555,6 +555,8 @@ export type JsonPathToAccessor<Path extends string> = Path extends `${infer P1}-
   ? JsonPathToAccessor<Rest>
   : Path extends `${infer P1}::${infer _}` // Handle type casting
   ? JsonPathToAccessor<P1>
+  : Path extends `${infer P1}${')' | ','}${infer _}` // Handle closing parenthesis and comma
+  ? P1
   : Path
 
 export type JsonPathToType<T, Path extends string> = Path extends ''

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -1,5 +1,5 @@
 import { PostgrestClient } from '../src/index'
-import { Database } from './types'
+import { CustomUserDataType, Database } from './types'
 
 const REST_URL = 'http://localhost:3000'
 const postgrest = new PostgrestClient<Database>(REST_URL)
@@ -1615,7 +1615,10 @@ test('select with no match', async () => {
 })
 
 test('update with no match - return=minimal', async () => {
-  const res = await postgrest.from('users').update({ data: '' }).eq('username', 'missing')
+  const res = await postgrest
+    .from('users')
+    .update({ data: '' as unknown as CustomUserDataType })
+    .eq('username', 'missing')
   expect(res).toMatchInlineSnapshot(`
     Object {
       "count": null,
@@ -1628,7 +1631,11 @@ test('update with no match - return=minimal', async () => {
 })
 
 test('update with no match - return=representation', async () => {
-  const res = await postgrest.from('users').update({ data: '' }).eq('username', 'missing').select()
+  const res = await postgrest
+    .from('users')
+    .update({ data: '' as unknown as CustomUserDataType })
+    .eq('username', 'missing')
+    .select()
   expect(res).toMatchInlineSnapshot(`
     Object {
       "count": null,

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -214,11 +214,37 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
 
 // Json Accessor with custom types overrides
 {
-  const { error } = await postgrest
+  const { data, error } = await postgrest
     .schema('personal')
     .from('users')
-    .select('data->foo->bar, data->foo->>baz')
+    .select('data->bar->baz, data->en, data->bar')
   if (error) {
     throw new Error(error.message)
   }
+  expectType<
+    {
+      baz: number
+      en: 'ONE' | 'TWO' | 'THREE'
+      bar: {
+        baz: number
+      }
+    }[]
+  >(data)
+}
+// Json string Accessor with custom types overrides
+{
+  const { data, error } = await postgrest
+    .schema('personal')
+    .from('users')
+    .select('data->bar->>baz, data->>en, data->>bar')
+  if (error) {
+    throw new Error(error.message)
+  }
+  expectType<
+    {
+      baz: string
+      en: 'ONE' | 'TWO' | 'THREE'
+      bar: string
+    }[]
+  >(data)
 }

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -211,3 +211,14 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   expectType<typeof x>(y)
   expectType<typeof x>(z)
 }
+
+// Json Accessor with custom types overrides
+{
+  const { error } = await postgrest
+    .schema('personal')
+    .from('users')
+    .select('data->foo->bar, data->foo->>baz')
+  if (error) {
+    throw new Error(error.message)
+  }
+}

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -52,87 +52,93 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   )
 
   {
-    const { data, error } = await postgrest.from('users').select('status').eq('status', 'ONLINE')
-    if (error) {
-      throw new Error(error.message)
+    const result = await postgrest.from('users').select('status').eq('status', 'ONLINE')
+    if (result.error) {
+      throw new Error(result.error.message)
     }
-    expectType<{ status: Database['public']['Enums']['user_status'] | null }[]>(data)
+    expectType<{ status: Database['public']['Enums']['user_status'] | null }[]>(result.data)
   }
 
   {
-    const { data, error } = await postgrest.from('users').select('status').neq('status', 'ONLINE')
-    if (error) {
-      throw new Error(error.message)
+    const result = await postgrest.from('users').select('status').neq('status', 'ONLINE')
+    if (result.error) {
+      throw new Error(result.error.message)
     }
-    expectType<{ status: Database['public']['Enums']['user_status'] | null }[]>(data)
+    expectType<{ status: Database['public']['Enums']['user_status'] | null }[]>(result.data)
   }
 
   {
-    const { data, error } = await postgrest
+    const result = await postgrest
       .from('users')
       .select('status')
       .in('status', ['ONLINE', 'OFFLINE'])
-    if (error) {
-      throw new Error(error.message)
+    if (result.error) {
+      throw new Error(result.error.message)
     }
-    expectType<{ status: Database['public']['Enums']['user_status'] | null }[]>(data)
+    expectType<{ status: Database['public']['Enums']['user_status'] | null }[]>(result.data)
   }
 
   {
-    const { data, error } = await postgrest
+    const result = await postgrest
       .from('best_friends')
       .select('users!first_user(status)')
       .eq('users.status', 'ONLINE')
-    if (error) {
-      throw new Error(error.message)
+    if (result.error) {
+      throw new Error(result.error.message)
     }
-    expectType<{ users: { status: Database['public']['Enums']['user_status'] | null } }[]>(data)
+    expectType<{ users: { status: Database['public']['Enums']['user_status'] | null } }[]>(
+      result.data
+    )
   }
 
   {
-    const { data, error } = await postgrest
+    const result = await postgrest
       .from('best_friends')
       .select('users!first_user(status)')
       .neq('users.status', 'ONLINE')
-    if (error) {
-      throw new Error(error.message)
+    if (result.error) {
+      throw new Error(result.error.message)
     }
-    expectType<{ users: { status: Database['public']['Enums']['user_status'] | null } }[]>(data)
+    expectType<{ users: { status: Database['public']['Enums']['user_status'] | null } }[]>(
+      result.data
+    )
   }
 
   {
-    const { data, error } = await postgrest
+    const result = await postgrest
       .from('best_friends')
       .select('users!first_user(status)')
       .in('users.status', ['ONLINE', 'OFFLINE'])
-    if (error) {
-      throw new Error(error.message)
+    if (result.error) {
+      throw new Error(result.error.message)
     }
-    expectType<{ users: { status: Database['public']['Enums']['user_status'] | null } }[]>(data)
+    expectType<{ users: { status: Database['public']['Enums']['user_status'] | null } }[]>(
+      result.data
+    )
   }
 }
 
 // can override result type
 {
-  const { data, error } = await postgrest
+  const result = await postgrest
     .from('users')
     .select('*, messages(*)')
     .returns<{ messages: { foo: 'bar' }[] }[]>()
-  if (error) {
-    throw new Error(error.message)
+  if (result.error) {
+    throw new Error(result.error.message)
   }
-  expectType<{ foo: 'bar' }[]>(data[0].messages)
+  expectType<{ foo: 'bar' }[]>(result.data[0].messages)
 }
 {
-  const { data, error } = await postgrest
+  const result = await postgrest
     .from('users')
     .insert({ username: 'foo' })
     .select('*, messages(*)')
     .returns<{ messages: { foo: 'bar' }[] }[]>()
-  if (error) {
-    throw new Error(error.message)
+  if (result.error) {
+    throw new Error(result.error.message)
   }
-  expectType<{ foo: 'bar' }[]>(data[0].messages)
+  expectType<{ foo: 'bar' }[]>(result.data[0].messages)
 }
 
 // cannot update non-updatable views
@@ -147,60 +153,54 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
 
 // spread resource with single column in select query
 {
-  const { data, error } = await postgrest
-    .from('messages')
-    .select('message, ...users(status)')
-    .single()
-  if (error) {
-    throw new Error(error.message)
+  const result = await postgrest.from('messages').select('message, ...users(status)').single()
+  if (result.error) {
+    throw new Error(result.error.message)
   }
   expectType<{ message: string | null; status: Database['public']['Enums']['user_status'] | null }>(
-    data
+    result.data
   )
 }
 
 // spread resource with all columns in select query
 {
-  const { data, error } = await postgrest.from('messages').select('message, ...users(*)').single()
-  if (error) {
-    throw new Error(error.message)
+  const result = await postgrest.from('messages').select('message, ...users(*)').single()
+  if (result.error) {
+    throw new Error(result.error.message)
   }
   expectType<Prettify<{ message: string | null } & Database['public']['Tables']['users']['Row']>>(
-    data
+    result.data
   )
 }
 
 // `count` in embedded resource
 {
-  const { data, error } = await postgrest.from('messages').select('message, users(count)').single()
-  if (error) {
-    throw new Error(error.message)
+  const result = await postgrest.from('messages').select('message, users(count)').single()
+  if (result.error) {
+    throw new Error(result.error.message)
   }
-  expectType<{ message: string | null; users: { count: number } }>(data)
+  expectType<{ message: string | null; users: { count: number } }>(result.data)
 }
 
 // json accessor in select query
 {
-  const { data, error } = await postgrest
-    .from('users')
-    .select('data->foo->bar, data->foo->>baz')
-    .single()
-  if (error) {
-    throw new Error(error.message)
+  const result = await postgrest.from('users').select('data->foo->bar, data->foo->>baz').single()
+  if (result.error) {
+    throw new Error(result.error.message)
   }
   // getting this w/o the cast, not sure why:
   // Parameter type Json is declared too wide for argument type Json
-  expectType<Json>(data.bar)
-  expectType<string>(data.baz)
+  expectType<Json>(result.data.bar)
+  expectType<string>(result.data.baz)
 }
 
 // rpc return type
 {
-  const { data, error } = await postgrest.rpc('get_status')
-  if (error) {
-    throw new Error(error.message)
+  const result = await postgrest.rpc('get_status')
+  if (result.error) {
+    throw new Error(result.error.message)
   }
-  expectType<'ONLINE' | 'OFFLINE'>(data)
+  expectType<'ONLINE' | 'OFFLINE'>(result.data)
 }
 
 // PostgrestBuilder's children retains class when using inherited methods
@@ -214,12 +214,12 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
 
 // Json Accessor with custom types overrides
 {
-  const { data, error } = await postgrest
+  const result = await postgrest
     .schema('personal')
     .from('users')
     .select('data->bar->baz, data->en, data->bar')
-  if (error) {
-    throw new Error(error.message)
+  if (result.error) {
+    throw new Error(result.error.message)
   }
   expectType<
     {
@@ -229,16 +229,16 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
         baz: number
       }
     }[]
-  >(data)
+  >(result.data)
 }
 // Json string Accessor with custom types overrides
 {
-  const { data, error } = await postgrest
+  const result = await postgrest
     .schema('personal')
     .from('users')
     .select('data->bar->>baz, data->>en, data->>bar')
-  if (error) {
-    throw new Error(error.message)
+  if (result.error) {
+    throw new Error(result.error.message)
   }
   expectType<
     {
@@ -246,5 +246,5 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
       en: 'ONE' | 'TWO' | 'THREE'
       bar: string
     }[]
-  >(data)
+  >(result.data)
 }

--- a/test/select-query-parser/parser.test-d.ts
+++ b/test/select-query-parser/parser.test-d.ts
@@ -662,3 +662,36 @@ import { selectParams } from '../relationships'
     0 as any as ParserError<'Unexpected input: ->->theme'>
   )
 }
+
+// JSON accessor within embedded tables
+{
+  expectType<ParseQuery<'users(data->bar->>baz, data->>en, data->bar)'>>([
+    {
+      type: 'field',
+      name: 'users',
+      children: [
+        {
+          type: 'field',
+          name: 'data',
+          alias: 'baz',
+          castType: 'text',
+          jsonPath: 'bar.baz',
+        },
+        {
+          type: 'field',
+          name: 'data',
+          alias: 'en',
+          castType: 'text',
+          jsonPath: 'en',
+        },
+        {
+          type: 'field',
+          name: 'data',
+          alias: 'bar',
+          castType: 'json',
+          jsonPath: 'bar',
+        },
+      ],
+    },
+  ])
+}

--- a/test/select-query-parser/parser.test-d.ts
+++ b/test/select-query-parser/parser.test-d.ts
@@ -81,17 +81,28 @@ import { selectParams } from '../relationships'
 // Select with JSON accessor
 {
   expectType<ParseQuery<'data->preferences->theme'>>([
-    { type: 'field', name: 'data', alias: 'theme', castType: 'json' },
+    {
+      type: 'field',
+      name: 'data',
+      alias: 'theme',
+      castType: 'json',
+      jsonPath: 'preferences.theme',
+    },
   ])
 }
 
 // Select with JSON accessor and text conversion
 {
   expectType<ParseQuery<'data->preferences->>theme'>>([
-    { type: 'field', name: 'data', alias: 'theme', castType: 'text' },
+    {
+      type: 'field',
+      name: 'data',
+      alias: 'theme',
+      castType: 'text',
+      jsonPath: 'preferences.theme',
+    },
   ])
 }
-
 // Select with spread
 {
   expectType<ParseQuery<'username, ...posts(id, title)'>>([
@@ -196,7 +207,13 @@ import { selectParams } from '../relationships'
         },
       ],
     },
-    { type: 'field', name: 'profile', alias: 'theme', castType: 'text' },
+    {
+      type: 'field',
+      name: 'profile',
+      alias: 'theme',
+      castType: 'text',
+      jsonPath: 'settings.theme',
+    },
   ])
 }
 {
@@ -327,7 +344,13 @@ import { selectParams } from '../relationships'
 // Select with nested JSON accessors
 {
   expectType<ParseQuery<'data->preferences->theme->color'>>([
-    { type: 'field', name: 'data', alias: 'color', castType: 'json' },
+    {
+      type: 'field',
+      name: 'data',
+      alias: 'color',
+      castType: 'json',
+      jsonPath: 'preferences.theme.color',
+    },
   ])
 }
 
@@ -464,7 +487,7 @@ import { selectParams } from '../relationships'
   expectType<ParseQuery<'id::text, created_at::date, data->age::int'>>([
     { type: 'field', name: 'id', castType: 'text' },
     { type: 'field', name: 'created_at', castType: 'date' },
-    { type: 'field', name: 'data', alias: 'age', castType: 'int' },
+    { type: 'field', name: 'data', alias: 'age', castType: 'int', jsonPath: 'age' },
   ])
 }
 
@@ -480,8 +503,8 @@ import { selectParams } from '../relationships'
 // select JSON accessor
 {
   expect<ParseQuery<typeof selectParams.selectJsonAccessor.select>>([
-    { type: 'field', name: 'data', alias: 'bar', castType: 'json' },
-    { type: 'field', name: 'data', alias: 'baz', castType: 'text' },
+    { type: 'field', name: 'data', alias: 'bar', castType: 'json', jsonPath: 'foo.bar' },
+    { type: 'field', name: 'data', alias: 'baz', castType: 'text', jsonPath: 'foo.baz' },
   ])
 }
 

--- a/test/select-query-parser/parser.test-d.ts
+++ b/test/select-query-parser/parser.test-d.ts
@@ -103,6 +103,31 @@ import { selectParams } from '../relationships'
     },
   ])
 }
+{
+  expectType<ParseQuery<'data->preferences->>theme, data->>some, data->foo->bar->>biz'>>([
+    {
+      type: 'field',
+      name: 'data',
+      alias: 'theme',
+      castType: 'text',
+      jsonPath: 'preferences.theme',
+    },
+    {
+      type: 'field',
+      name: 'data',
+      alias: 'some',
+      castType: 'text',
+      jsonPath: 'some',
+    },
+    {
+      type: 'field',
+      name: 'data',
+      alias: 'biz',
+      castType: 'text',
+      jsonPath: 'foo.bar.biz',
+    },
+  ])
+}
 // Select with spread
 {
   expectType<ParseQuery<'username, ...posts(id, title)'>>([

--- a/test/select-query-parser/result.test-d.ts
+++ b/test/select-query-parser/result.test-d.ts
@@ -118,3 +118,34 @@ type SelectQueryFromTableResult<
   expectType<typeof result1>(result2!)
   expectType<typeof result2>(result3!)
 }
+
+{
+  type SelectQueryFromTableResult<
+    TableName extends keyof Database['personal']['Tables'],
+    Q extends string
+  > = GetResult<
+    Database['personal'],
+    Database['personal']['Tables'][TableName]['Row'],
+    TableName,
+    Database['personal']['Tables'][TableName]['Relationships'],
+    Q
+  >
+
+  let result: SelectQueryFromTableResult<'users', `data->bar->baz, data->en, data->bar`>
+  let expected: {
+    baz: number
+    en: 'ONE' | 'TWO' | 'THREE'
+    bar: {
+      baz: number
+    }
+  }
+  expectType<TypeEqual<typeof result, typeof expected>>(true)
+
+  let result2: SelectQueryFromTableResult<'users', `data->bar->>baz, data->>en, data->>bar`>
+  let expected2: {
+    baz: string
+    en: 'ONE' | 'TWO' | 'THREE'
+    bar: string
+  }
+  expectType<TypeEqual<typeof result2, typeof expected2>>(true)
+}

--- a/test/select-query-parser/result.test-d.ts
+++ b/test/select-query-parser/result.test-d.ts
@@ -120,7 +120,7 @@ type SelectQueryFromTableResult<
 }
 
 {
-  type SelectQueryFromTableResult<
+  type SelectQueryFromPersonalTableResult<
     TableName extends keyof Database['personal']['Tables'],
     Q extends string
   > = GetResult<
@@ -130,22 +130,38 @@ type SelectQueryFromTableResult<
     Database['personal']['Tables'][TableName]['Relationships'],
     Q
   >
-
-  let result: SelectQueryFromTableResult<'users', `data->bar->baz, data->en, data->bar`>
-  let expected: {
-    baz: number
-    en: 'ONE' | 'TWO' | 'THREE'
-    bar: {
+  // Should work with Json object accessor
+  {
+    let result: SelectQueryFromPersonalTableResult<'users', `data->bar->baz, data->en, data->bar`>
+    let expected: {
       baz: number
+      en: 'ONE' | 'TWO' | 'THREE'
+      bar: {
+        baz: number
+      }
     }
+    expectType<TypeEqual<typeof result, typeof expected>>(true)
   }
-  expectType<TypeEqual<typeof result, typeof expected>>(true)
-
-  let result2: SelectQueryFromTableResult<'users', `data->bar->>baz, data->>en, data->>bar`>
-  let expected2: {
-    baz: string
-    en: 'ONE' | 'TWO' | 'THREE'
-    bar: string
+  // Should work with Json string accessor
+  {
+    let result: SelectQueryFromPersonalTableResult<
+      'users',
+      `data->bar->>baz, data->>en, data->>bar`
+    >
+    let expected: {
+      baz: string
+      en: 'ONE' | 'TWO' | 'THREE'
+      bar: string
+    }
+    expectType<TypeEqual<typeof result, typeof expected>>(true)
   }
-  expectType<TypeEqual<typeof result2, typeof expected2>>(true)
+  // Should fallback to defaults if unknown properties are mentionned
+  {
+    let result: SelectQueryFromPersonalTableResult<'users', `data->bar->>nope, data->neither`>
+    let expected: {
+      nope: string
+      neither: Json
+    }
+    expectType<TypeEqual<typeof result, typeof expected>>(true)
+  }
 }

--- a/test/select-query-parser/result.test-d.ts
+++ b/test/select-query-parser/result.test-d.ts
@@ -164,4 +164,33 @@ type SelectQueryFromTableResult<
     }
     expectType<TypeEqual<typeof result, typeof expected>>(true)
   }
+  // Should work with embeded Json object accessor
+  {
+    let result: SelectQueryFromTableResult<'messages', `users(data->bar->baz, data->en, data->bar)`>
+    let expected: {
+      users: {
+        baz: number
+        en: 'ONE' | 'TWO' | 'THREE'
+        bar: {
+          baz: number
+        }
+      }
+    }
+    expectType<TypeEqual<typeof result, typeof expected>>(true)
+  }
+  // Should work with embeded Json string accessor
+  {
+    let result: SelectQueryFromTableResult<
+      'messages',
+      `users(data->bar->>baz, data->>en, data->>bar)`
+    >
+    let expected: {
+      users: {
+        baz: string
+        en: 'ONE' | 'TWO' | 'THREE'
+        bar: string
+      }
+    }
+    expectType<TypeEqual<typeof result, typeof expected>>(true)
+  }
 }

--- a/test/select-query-parser/select.test-d.ts
+++ b/test/select-query-parser/select.test-d.ts
@@ -3,7 +3,7 @@ import { TypeEqual } from 'ts-expect'
 import { Json } from '../../src/select-query-parser/types'
 import { SelectQueryError } from '../../src/select-query-parser/utils'
 import { Prettify } from '../../src/types'
-import { Database } from '../types'
+import { CustomUserDataType, Database } from '../types'
 import { selectQueries } from '../relationships'
 
 // This test file is here to ensure that for a query against a specfic datatabase
@@ -617,7 +617,7 @@ type Schema = Database['public']
     users: {
       age_range: unknown | null
       catchphrase: unknown | null
-      data: Json | null
+      data: CustomUserDataType | null
       status: Database['public']['Enums']['user_status'] | null
       username: string
     }

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,6 +1,6 @@
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
 
-type CustomUserDataType = {
+export type CustomUserDataType = {
   foo: string
   bar: {
     baz: number
@@ -412,21 +412,21 @@ export type Database = {
         Row: {
           age_range: unknown | null
           catchphrase: unknown | null
-          data: Json | null
+          data: CustomUserDataType | null
           status: Database['public']['Enums']['user_status'] | null
           username: string
         }
         Insert: {
           age_range?: unknown | null
           catchphrase?: unknown | null
-          data?: Json | null
+          data?: CustomUserDataType | null
           status?: Database['public']['Enums']['user_status'] | null
           username: string
         }
         Update: {
           age_range?: unknown | null
           catchphrase?: unknown | null
-          data?: Json | null
+          data?: CustomUserDataType | null
           status?: Database['public']['Enums']['user_status'] | null
           username?: string
         }

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,24 +1,32 @@
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
 
+type CustomUserDataType = {
+  foo: string
+  bar: {
+    baz: number
+  }
+  en: 'ONE' | 'TWO' | 'THREE'
+}
+
 export type Database = {
   personal: {
     Tables: {
       users: {
         Row: {
           age_range: unknown | null
-          data: Json | null
+          data: CustomUserDataType | null
           status: Database['public']['Enums']['user_status'] | null
           username: string
         }
         Insert: {
           age_range?: unknown | null
-          data?: Json | null
+          data?: CustomUserDataType | null
           status?: Database['public']['Enums']['user_status'] | null
           username: string
         }
         Update: {
           age_range?: unknown | null
-          data?: Json | null
+          data?: CustomUserDataType | null
           status?: Database['public']['Enums']['user_status'] | null
           username?: string
         }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allow users to override Json type with custom types, and take into account the "json accessor" to infer the proper resulting type.

## What is the current behavior?

Given a table defined like so:

```
type CustomJsonType = {
  foo: string
  bar: {
    baz: number
  }
  en: 'ONE' | 'TWO' | 'THREE'
}
table: {
 data: CustomJsonType | null
}
```

The following behavior is observed:

```ts
select(`data`) -> {data: CustomJsonType | null}
select(`data->bar`) -> {bar: Json}
select(`data->>bar`) -> {bar: string}
select(`data->>en`) -> {bar: string}
select(`data->bar->baz`) -> {baz: Json}
```

## What is the new behavior?

```ts
select(`data`) -> {data: CustomJsonType | null}
select(`data->bar`) -> { bar:  { baz: number } }
// Preserve the postgrest casting behaviour due to ->> accessor
select(`data->>bar`) -> {bar: string}
// Preserve the union of string
select(`data->>en`) -> {bar:  'ONE' | 'TWO' | 'THREE'}
// Preserve the accessed ressource type
select(`data->bar->baz`) -> {baz: number}
// Fallback on the default behavior for non-matching properties
select(`data->bar->nope`) -> {nope: Json}
select(`data->bar->>nope`) -> {nope: string}
```

## Additional context

Add any other context or screenshots.
