### PR TITLE
types: export GenericSchema type from types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export type {
   PostgrestResponseSuccess,
   PostgrestSingleResponse,
   PostgrestMaybeSingleResponse,
+  GenericSchema,
 } from './types'
 // https://github.com/supabase/postgrest-js/issues/551
 // To be replaced with a helper type that only uses public types


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add the export of `GenericSchema` in order to allow to use it as base to Database type argument in the PostgrestClient.

## What is the current behavior?

The type is not exported, so if we are using the client without the generated types, we are not able to get type hints.

## What is the new behavior?

Exporting it, we can extend it and get type hints.

## Additional context

Expected behavior: ![image](https://github.com/user-attachments/assets/07c20572-c143-40d0-8ead-0c20f54d36b3)

