### PR TITLE
Export ResolveFilterValue and ResolveFilterRelationshipValue

### DIFF
--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -1,5 +1,5 @@
 import PostgrestTransformBuilder from './PostgrestTransformBuilder'
-import { GenericSchema } from './types'
+import { GenericSchema, ResolveFilterValue } from './types'
 
 type FilterOperator =
   | 'eq'
@@ -24,37 +24,6 @@ type FilterOperator =
   | 'plfts'
   | 'phfts'
   | 'wfts'
-
-// Match relationship filters with `table.column` syntax and resolve underlying
-// column value. If not matched, fallback to generic type.
-// TODO: Validate the relationship itself ala select-query-parser. Currently we
-// assume that all tables have valid relationships to each other, despite
-// nonexistent foreign keys.
-type ResolveFilterValue<
-  Schema extends GenericSchema,
-  Row extends Record<string, unknown>,
-  ColumnName extends string
-> = ColumnName extends `${infer RelationshipTable}.${infer Remainder}`
-  ? Remainder extends `${infer _}.${infer _}`
-    ? ResolveFilterValue<Schema, Row, Remainder>
-    : ResolveFilterRelationshipValue<Schema, RelationshipTable, Remainder>
-  : ColumnName extends keyof Row
-  ? Row[ColumnName]
-  : never
-
-type ResolveFilterRelationshipValue<
-  Schema extends GenericSchema,
-  RelationshipTable extends string,
-  RelationshipColumn extends string
-> = Schema['Tables'] & Schema['Views'] extends infer TablesAndViews
-  ? RelationshipTable extends keyof TablesAndViews
-    ? 'Row' extends keyof TablesAndViews[RelationshipTable]
-      ? RelationshipColumn extends keyof TablesAndViews[RelationshipTable]['Row']
-        ? TablesAndViews[RelationshipTable]['Row'][RelationshipColumn]
-        : unknown
-      : unknown
-    : unknown
-  : never
 
 export default class PostgrestFilterBuilder<
   Schema extends GenericSchema,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Export types `ResolveFilterValue` and `ResolveFilterRelationshipValue`

Related to: https://github.com/supabase/supabase-js/issues/1351

## What is the current behavior?

Both types are not exported. If one has to use any of these types, they have to be copied.
