### PR TITLE
fix(types): type instantiation is excessively deep and possibly infinite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "tsd": "^0.31.2",
         "type-fest": "^4.32.0",
         "typedoc": "^0.22.16",
-        "typescript": "^4.7.4",
+        "typescript": "^4.5.5",
         "wait-for-localhost-cli": "^3.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "ts-expect": "^1.3.0",
         "ts-jest": "^28.0.3",
         "tsd": "^0.31.2",
+        "type-fest": "^4.32.0",
         "typedoc": "^0.22.16",
         "typescript": "4.5.5",
         "wait-for-localhost-cli": "^3.0.0"
@@ -1310,6 +1311,19 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5904,12 +5918,13 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.32.0.tgz",
+      "integrity": "sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7224,6 +7239,14 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true
+        }
       }
     },
     "ansi-regex": {
@@ -10554,9 +10577,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.32.0.tgz",
+      "integrity": "sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==",
       "dev": true
     },
     "typedoc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "tsd": "^0.31.2",
         "type-fest": "^4.32.0",
         "typedoc": "^0.22.16",
-        "typescript": "4.5.5",
+        "typescript": "^4.7.4",
         "wait-for-localhost-cli": "^3.0.0"
       }
     },
@@ -5993,9 +5993,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -10629,9 +10629,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "tsd": "^0.31.2",
     "type-fest": "^4.32.0",
     "typedoc": "^0.22.16",
-    "typescript": "4.5.5",
+    "typescript": "^4.7.4",
     "wait-for-localhost-cli": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "tsd": "^0.31.2",
     "type-fest": "^4.32.0",
     "typedoc": "^0.22.16",
-    "typescript": "^4.7.4",
+    "typescript": "^4.5.5",
     "wait-for-localhost-cli": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "ts-expect": "^1.3.0",
     "ts-jest": "^28.0.3",
     "tsd": "^0.31.2",
+    "type-fest": "^4.32.0",
     "typedoc": "^0.22.16",
     "typescript": "4.5.5",
     "wait-for-localhost-cli": "^3.0.0"

--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -273,11 +273,13 @@ export default class PostgrestFilterBuilder<
    */
   in<ColumnName extends string>(
     column: ColumnName,
-    values: ResolveFilterValue<Schema, Row, ColumnName> extends infer ResolvedFilterValue
-      ? ResolvedFilterValue extends never
-        ? unknown[]
-        : ReadonlyArray<ResolvedFilterValue>
-      : never
+    values: ReadonlyArray<
+      ResolveFilterValue<Schema, Row, ColumnName> extends infer ResolvedFilterValue
+        ? ResolvedFilterValue extends never
+          ? unknown[]
+          : ResolvedFilterValue
+        : never
+    >
   ): this {
     const cleanedValues = Array.from(new Set(values))
       .map((s) => {

--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -75,9 +75,9 @@ export default class PostgrestFilterBuilder<
     column: ColumnName,
     value: ResolveFilterValue<Schema, Row, ColumnName> extends infer ResolvedFilterValue
       ? ResolvedFilterValue extends never
-        ? NonNullable<unknown>
+        ? unknown
         : NonNullable<ResolvedFilterValue>
-      : never
+      : unknown
   ): this {
     this.url.searchParams.append(column, `eq.${value}`)
     return this
@@ -95,7 +95,7 @@ export default class PostgrestFilterBuilder<
       ? ResolvedFilterValue extends never
         ? unknown
         : NonNullable<ResolvedFilterValue>
-      : never
+      : unknown
   ): this {
     this.url.searchParams.append(column, `neq.${value}`)
     return this

--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -26,6 +26,10 @@ type FilterOperator =
   | 'phfts'
   | 'wfts'
 
+export type IsStringOperator<Path extends string> = Path extends `${string}->>${string}`
+  ? true
+  : false
+
 // Match relationship filters with `table.column` syntax and resolve underlying
 // column value. If not matched, fallback to generic type.
 // TODO: Validate the relationship itself ala select-query-parser. Currently we
@@ -41,9 +45,11 @@ type ResolveFilterValue<
     : ResolveFilterRelationshipValue<Schema, RelationshipTable, Remainder>
   : ColumnName extends keyof Row
   ? Row[ColumnName]
-  : // If the column selection is a jsonpath like `data->value` we attempt to match
+  : // If the column selection is a jsonpath like `data->value` or `data->>value` we attempt to match
   // the expected type with the parsed custom json type
-  JsonPathToType<Row, JsonPathToAccessor<ColumnName>> extends infer JsonPathValue
+  IsStringOperator<ColumnName> extends true
+  ? string
+  : JsonPathToType<Row, JsonPathToAccessor<ColumnName>> extends infer JsonPathValue
   ? JsonPathValue extends never
     ? never
     : JsonPathValue

--- a/src/PostgrestFilterBuilder.ts
+++ b/src/PostgrestFilterBuilder.ts
@@ -73,9 +73,11 @@ export default class PostgrestFilterBuilder<
    */
   eq<ColumnName extends string>(
     column: ColumnName,
-    value: ResolveFilterValue<Schema, Row, ColumnName> extends never
-      ? NonNullable<unknown>
-      : NonNullable<ResolveFilterValue<Schema, Row, ColumnName>>
+    value: ResolveFilterValue<Schema, Row, ColumnName> extends infer ResolvedFilterValue
+      ? ResolvedFilterValue extends never
+        ? NonNullable<unknown>
+        : NonNullable<ResolvedFilterValue>
+      : never
   ): this {
     this.url.searchParams.append(column, `eq.${value}`)
     return this
@@ -89,9 +91,11 @@ export default class PostgrestFilterBuilder<
    */
   neq<ColumnName extends string>(
     column: ColumnName,
-    value: ResolveFilterValue<Schema, Row, ColumnName> extends never
-      ? unknown
-      : ResolveFilterValue<Schema, Row, ColumnName>
+    value: ResolveFilterValue<Schema, Row, ColumnName> extends infer ResolvedFilterValue
+      ? ResolvedFilterValue extends never
+        ? unknown
+        : NonNullable<ResolvedFilterValue>
+      : never
   ): this {
     this.url.searchParams.append(column, `neq.${value}`)
     return this
@@ -269,9 +273,11 @@ export default class PostgrestFilterBuilder<
    */
   in<ColumnName extends string>(
     column: ColumnName,
-    values: ResolveFilterValue<Schema, Row, ColumnName> extends never
-      ? unknown[]
-      : ReadonlyArray<ResolveFilterValue<Schema, Row, ColumnName>>
+    values: ResolveFilterValue<Schema, Row, ColumnName> extends infer ResolvedFilterValue
+      ? ResolvedFilterValue extends never
+        ? unknown[]
+        : ReadonlyArray<ResolvedFilterValue>
+      : never
   ): this {
     const cleanedValues = Array.from(new Set(values))
       .map((s) => {

--- a/test/issue-1354-d.ts
+++ b/test/issue-1354-d.ts
@@ -212,4 +212,17 @@ const postgrestOverrideTypes = new PostgrestClient<DatabaseOverride>('http://loc
     })
     .eq('id', res.data.id)
   expectType<null>(result.data)
+  const resIn = await postgrestOverrideTypes
+    .from('foo')
+    .select('id, bar, baz')
+    .in('bar', [
+      { version: 1, events: [] },
+      { version: 2, events: [] },
+    ])
+    .single()
+
+  if (resIn.error) {
+    throw new Error(resIn.error.message)
+  }
+  expectType<{ id: string; bar: Custom; baz: Custom }>(resIn.data)
 }

--- a/test/issue-1354-d.ts
+++ b/test/issue-1354-d.ts
@@ -191,6 +191,35 @@ const postgrestOverrideTypes = new PostgrestClient<DatabaseOverride>('http://loc
   expectType<null>(result.data)
 }
 
+// basic types with postgres jsonpath selector
+{
+  const res = await postgrest.from('foo').select('id, bar, baz').eq('bar->version', 31).single()
+
+  const bar = {} as Json
+  const baz = {} as Json
+  if (res.error) {
+    throw new Error(res.error.message)
+  }
+  const result = await postgrest
+    .from('foo')
+    .update({
+      bar,
+      baz,
+    })
+    .eq('bar->version', 31)
+  expectType<null>(result.data)
+  const resIn = await postgrest
+    .from('foo')
+    .select('id, bar, baz')
+    .in('bar->version', [1, 2])
+    .single()
+
+  if (resIn.error) {
+    throw new Error(resIn.error.message)
+  }
+  expectType<{ id: string; bar: Json; baz: Json }>(resIn.data)
+}
+
 // extended types
 {
   const res = await postgrestOverrideTypes
@@ -219,6 +248,39 @@ const postgrestOverrideTypes = new PostgrestClient<DatabaseOverride>('http://loc
       { version: 1, events: [] },
       { version: 2, events: [] },
     ])
+    .single()
+
+  if (resIn.error) {
+    throw new Error(resIn.error.message)
+  }
+  expectType<{ id: string; bar: Custom; baz: Custom }>(resIn.data)
+}
+
+// extended types with postgres jsonpath selector
+{
+  const res = await postgrestOverrideTypes
+    .from('foo')
+    .select('id, bar, baz')
+    .eq('bar->version', 31)
+    .single()
+
+  const bar = {} as Custom
+  const baz = {} as Custom
+  if (res.error) {
+    throw new Error(res.error.message)
+  }
+  const result = await postgrestOverrideTypes
+    .from('foo')
+    .update({
+      bar,
+      baz,
+    })
+    .eq('bar->version', res.data.bar.version)
+  expectType<null>(result.data)
+  const resIn = await postgrestOverrideTypes
+    .from('foo')
+    .select('id, bar, baz')
+    .in('bar->version', [1, 32])
     .single()
 
   if (resIn.error) {

--- a/test/issue-1354-d.ts
+++ b/test/issue-1354-d.ts
@@ -280,7 +280,13 @@ const postgrestOverrideTypes = new PostgrestClient<DatabaseOverride>('http://loc
   const resIn = await postgrestOverrideTypes
     .from('foo')
     .select('id, bar, baz')
-    .in('bar->version', [1, 32])
+    .in('bar->version', [31])
+    .single()
+  await postgrestOverrideTypes
+    .from('foo')
+    .select('id, bar, baz')
+    // the type become a string when using the string json accessor operator
+    .in('bar->>version', ['something'])
     .single()
 
   if (resIn.error) {

--- a/test/issue-1354-d.ts
+++ b/test/issue-1354-d.ts
@@ -10,27 +10,27 @@ export type Database = {
       foo: {
         Row: {
           created_at: string | null
-          bar: Custom
+          bar: Json
           id: string
-          baz: Custom
+          baz: Json
           game_id: string
           updated_at: string | null
           user_id: string | null
         }
         Insert: {
           created_at?: string | null
-          bar: Custom
+          bar: Json
           id?: string
-          baz: Custom
+          baz: Json
           game_id: string
           updated_at?: string | null
           user_id?: string | null
         }
         Update: {
           created_at?: string | null
-          bar?: Custom
+          bar?: Json
           id?: string
-          baz?: Custom
+          baz?: Json
           game_id?: string
           updated_at?: string | null
           user_id?: string | null

--- a/test/issue-1354-d.ts
+++ b/test/issue-1354-d.ts
@@ -10,27 +10,27 @@ export type Database = {
       foo: {
         Row: {
           created_at: string | null
-          bar: Json
+          bar: Custom
           id: string
-          baz: Json
+          baz: Custom
           game_id: string
           updated_at: string | null
           user_id: string | null
         }
         Insert: {
           created_at?: string | null
-          bar: Json
+          bar: Custom
           id?: string
-          baz: Json
+          baz: Custom
           game_id: string
           updated_at?: string | null
           user_id?: string | null
         }
         Update: {
           created_at?: string | null
-          bar?: Json
+          bar?: Custom
           id?: string
-          baz?: Json
+          baz?: Custom
           game_id?: string
           updated_at?: string | null
           user_id?: string | null

--- a/test/issue-1354-d.ts
+++ b/test/issue-1354-d.ts
@@ -1,0 +1,215 @@
+import { expectType } from 'tsd'
+import { PostgrestClient } from '../src/index'
+import type { MergeDeep } from 'type-fest'
+
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+
+export type Database = {
+  public: {
+    Tables: {
+      foo: {
+        Row: {
+          created_at: string | null
+          bar: Json
+          id: string
+          baz: Json
+          game_id: string
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          bar: Json
+          id?: string
+          baz: Json
+          game_id: string
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          bar?: Json
+          id?: string
+          baz?: Json
+          game_id?: string
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: []
+      }
+    }
+    Views: {}
+    Functions: {}
+    Enums: {}
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type PublicSchema = Database[Extract<keyof Database, 'public'>]
+
+export type Tables<
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema['Tables'] & PublicSchema['Views'])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions['schema']]['Tables'] &
+        Database[PublicTableNameOrOptions['schema']]['Views'])
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions['schema']]['Tables'] &
+      Database[PublicTableNameOrOptions['schema']]['Views'])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views'])
+  ? (PublicSchema['Tables'] & PublicSchema['Views'])[PublicTableNameOrOptions] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : never
+
+export type TablesInsert<
+  PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
+  ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : never
+
+export type TablesUpdate<
+  PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
+  ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : never
+
+export type Enums<
+  PublicEnumNameOrOptions extends keyof PublicSchema['Enums'] | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions['schema']]['Enums']
+    : never = never
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema['Enums']
+  ? PublicSchema['Enums'][PublicEnumNameOrOptions]
+  : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema['CompositeTypes']
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    : never = never
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema['CompositeTypes']
+  ? PublicSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+  : never
+
+type Custom = {
+  version: number
+  events: Array<{
+    type: string
+    [x: string]: any
+  }>
+}
+
+export type DatabaseOverride = MergeDeep<
+  Database,
+  {
+    public: {
+      Tables: {
+        foo: {
+          Row: {
+            bar: Custom
+            baz: Custom
+          }
+          Insert: {
+            bar: Custom
+            baz: Custom
+          }
+          Update: {
+            bar?: Custom
+            baz?: Custom
+          }
+        }
+      }
+    }
+  }
+>
+
+const postgrest = new PostgrestClient<Database>('http://localhost:3000')
+
+const postgrestOverrideTypes = new PostgrestClient<DatabaseOverride>('http://localhost:3000')
+
+// Basic types
+{
+  const res = await postgrest.from('foo').select('id').eq('id', '...').single()
+
+  const bar = {} as Custom
+  const baz = {} as Custom
+  if (res.error) {
+    throw new Error(res.error.message)
+  }
+  const result = await postgrest
+    .from('foo')
+    .update({
+      bar,
+      baz,
+    })
+    .eq('id', res.data.id)
+  expectType<null>(result.data)
+}
+
+// extended types
+{
+  const res = await postgrestOverrideTypes
+    .from('foo')
+    .select('id, bar, baz')
+    .eq('id', '...')
+    .single()
+
+  const bar = {} as Custom
+  const baz = {} as Custom
+  if (res.error) {
+    throw new Error(res.error.message)
+  }
+  const result = await postgrestOverrideTypes
+    .from('foo')
+    .update({
+      bar,
+      baz,
+    })
+    .eq('id', res.data.id)
+  expectType<null>(result.data)
+}

--- a/test/relationships.ts
+++ b/test/relationships.ts
@@ -1830,12 +1830,7 @@ test('self reference relation via column', async () => {
 })
 
 test('aggregate on missing column with alias', async () => {
-  const res = await selectQueries.aggregateOnMissingColumnWithAlias
-    // @ts-expect-error should not be able to eq 'id' since the column does not
-    // exist
-    .eq('id', 2)
-    .limit(1)
-    .single()
+  const res = await selectQueries.aggregateOnMissingColumnWithAlias.eq('id', 2).limit(1).single()
   expect(res).toMatchInlineSnapshot(`
     Object {
       "count": null,

--- a/test/relationships.ts
+++ b/test/relationships.ts
@@ -1830,7 +1830,12 @@ test('self reference relation via column', async () => {
 })
 
 test('aggregate on missing column with alias', async () => {
-  const res = await selectQueries.aggregateOnMissingColumnWithAlias.eq('id', 1).limit(1).single()
+  const res = await selectQueries.aggregateOnMissingColumnWithAlias
+    // @ts-expect-error should not be able to eq 'id' since the column does not
+    // exist
+    .eq('id', 2)
+    .limit(1)
+    .single()
   expect(res).toMatchInlineSnapshot(`
     Object {
       "count": null,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix a case on typescript > 4.5.5 where using `MergeDeep` override lead to an error of `Type instantiation is excessively deep and possibly infinite`. Use a trick to "force typescript to infer final type" instead of doing a shallow inspection and warning about possible infinite recursion.

This is a bit black magic'ish but it fix the issue on the reproduction case 😅 

## Additional context

Related: https://github.com/supabase/supabase-js/issues/1354