### PR TITLE
feat(types): add override types method

### DIFF
--- a/src/PostgrestBuilder.ts
+++ b/src/PostgrestBuilder.ts
@@ -6,6 +6,8 @@ import type {
   PostgrestSingleResponse,
   PostgrestResponseSuccess,
   CheckMatchingArrayTypes,
+  MergePartialResult,
+  IsValidResultOverride,
 } from './types'
 import PostgrestError from './PostgrestError'
 
@@ -224,6 +226,45 @@ export default abstract class PostgrestBuilder<Result, ThrowOnError extends bool
   returns<NewResult>(): PostgrestBuilder<CheckMatchingArrayTypes<Result, NewResult>, ThrowOnError> {
     return this as unknown as PostgrestBuilder<
       CheckMatchingArrayTypes<Result, NewResult>,
+      ThrowOnError
+    >
+  }
+
+  /**
+   * Override the type of the returned `data` field in the response.
+   *
+   * @typeParam NewResult - The new type to cast the response data to
+   * @typeParam Options - Optional type configuration (defaults to { merge: true })
+   * @typeParam Options.merge - When true, merges the new type with existing return type. When false, replaces the existing types entirely (defaults to true)
+   * @example
+   * ```typescript
+   * // Merge with existing types (default behavior)
+   * const query = supabase
+   *   .from('users')
+   *   .select()
+   *   .overrideTypes<{ custom_field: string }>()
+   *
+   * // Replace existing types completely
+   * const replaceQuery = supabase
+   *   .from('users')
+   *   .select()
+   *   .overrideTypes<{ id: number; name: string }, { merge: false }>()
+   * ```
+   * @returns A PostgrestBuilder instance with the new type
+   */
+  overrideTypes<
+    NewResult,
+    Options extends { merge?: boolean } = { merge: true }
+  >(): PostgrestBuilder<
+    IsValidResultOverride<Result, NewResult, true, false, false> extends true
+      ? MergePartialResult<NewResult, Result, Options>
+      : CheckMatchingArrayTypes<Result, NewResult>,
+    ThrowOnError
+  > {
+    return this as unknown as PostgrestBuilder<
+      IsValidResultOverride<Result, NewResult, true, false, false> extends true
+        ? MergePartialResult<NewResult, Result, Options>
+        : CheckMatchingArrayTypes<Result, NewResult>,
       ThrowOnError
     >
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,20 @@ type NonRecursiveType = BuiltIns | Function | (new (...arguments_: any[]) => unk
 type BuiltIns = Primitive | void | Date | RegExp
 type Primitive = null | undefined | string | number | boolean | symbol | bigint
 
+export type IsValidResultOverride<Result, NewResult, Ok, ErrorResult, ErrorNewResult> =
+  Result extends any[]
+    ? NewResult extends any[]
+      ? // Both are arrays - valid
+        Ok
+      : ErrorResult
+    : NewResult extends any[]
+    ? ErrorNewResult
+    : // Neither are arrays - valid
+    // Preserve the optionality of the result if the overriden type is an object (case of chaining with `maybeSingle`)
+    ContainsNull<Result> extends true
+    ? Ok | null
+    : Ok
+
 /**
  * Utility type to check if array types match between Result and NewResult.
  * Returns either the valid NewResult type or an error message type.
@@ -100,19 +114,43 @@ export type CheckMatchingArrayTypes<Result, NewResult> =
   // If the result is a QueryError we allow the user to override anyway
   Result extends SelectQueryError<string>
     ? NewResult
-    : // Otherwise, we check basic type matching (array should be override by array, object by object)
-    Result extends any[]
-    ? NewResult extends any[]
-      ? NewResult // Both are arrays - valid
-      : {
+    : IsValidResultOverride<
+        Result,
+        NewResult,
+        NewResult,
+        {
           Error: 'Type mismatch: Cannot cast array result to a single object. Use .returns<Array<YourType>> for array results or .single() to convert the result to a single object'
+        },
+        {
+          Error: 'Type mismatch: Cannot cast single object to array type. Remove Array wrapper from return type or make sure you are not using .single() up in the calling chain'
         }
-    : NewResult extends any[]
-    ? {
-        Error: 'Type mismatch: Cannot cast single object to array type. Remove Array wrapper from return type or make sure you are not using .single() up in the calling chain'
-      }
-    : // Neither are arrays - valid
-    // Preserve the optionality of the result if the overriden type is an object (case of chaining with `maybeSingle`)
-    ContainsNull<Result> extends true
-    ? NewResult | null
-    : NewResult
+      >
+
+type Simplify<T> = T extends object ? { [K in keyof T]: T[K] } : T
+
+type MergeDeep<New, Row> = {
+  [K in keyof New | keyof Row]: K extends keyof Row
+    ? K extends keyof New
+      ? IsPlainObject<New[K]> extends true
+        ? IsPlainObject<Row[K]> extends true
+          ? MergeDeep<New[K], Row[K]>
+          : Row[K]
+        : Row[K]
+      : Row[K]
+    : K extends keyof New
+    ? New[K]
+    : never
+}
+
+// Helper to check if a type is a plain object (not an array)
+type IsPlainObject<T> = T extends any[] ? false : T extends object ? true : false
+
+// Merge the new result with the original (Result) when partial is true.
+// If NewResult is an array, merge each element.
+export type MergePartialResult<NewResult, Result, Options> = Options extends { merge: true }
+  ? Result extends any[]
+    ? NewResult extends any[]
+      ? Array<Simplify<MergeDeep<NewResult[number], Result[number]>>>
+      : never
+    : Simplify<MergeDeep<NewResult, Result>>
+  : NewResult

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,7 +145,7 @@ type MergeDeep<New, Row> = {
 // Helper to check if a type is a plain object (not an array)
 type IsPlainObject<T> = T extends any[] ? false : T extends object ? true : false
 
-// Merge the new result with the original (Result) when partial is true.
+// Merge the new result with the original (Result) when merge option is true.
 // If NewResult is an array, merge each element.
 export type MergePartialResult<NewResult, Result, Options> = Options extends { merge: true }
   ? Result extends any[]

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -140,6 +140,30 @@ test('basic select returns from builder', async () => {
   `)
 })
 
+test('basic select overrideTypes from builder', async () => {
+  const res = await postgrest
+    .from('users')
+    .select()
+    .eq('username', 'supabot')
+    .single()
+    .overrideTypes<{ status: 'ONLINE' | 'OFFLINE' }>()
+  expect(res).toMatchInlineSnapshot(`
+    Object {
+      "count": null,
+      "data": Object {
+        "age_range": "[1,2)",
+        "catchphrase": "'cat' 'fat'",
+        "data": null,
+        "status": "ONLINE",
+        "username": "supabot",
+      },
+      "error": null,
+      "status": 200,
+      "statusText": "OK",
+    }
+  `)
+})
+
 test('basic select view', async () => {
   const res = await postgrest.from('updatable_view').select()
   expect(res).toMatchInlineSnapshot(`

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -161,7 +161,7 @@ test('basic select overrideTypes from builder', async () => {
       "status": 200,
       "statusText": "OK",
     }
-  `);
+  `)
 })
 
 test('basic select with maybeSingle yielding more than one result', async () => {

--- a/test/override-types.test-d.ts
+++ b/test/override-types.test-d.ts
@@ -1,0 +1,126 @@
+import { expectType } from 'tsd'
+import { TypeEqual } from 'ts-expect'
+import { PostgrestClient } from '../src'
+import { CustomUserDataType, Database } from './types'
+
+const REST_URL = 'http://localhost:54321'
+const postgrest = new PostgrestClient<Database>(REST_URL)
+
+// Test merge array result to object should error
+{
+  const singleResult = await postgrest
+    .from('users')
+    .select()
+    .overrideTypes<{ custom_field: string }>()
+  if (singleResult.error) {
+    throw new Error(singleResult.error.message)
+  }
+  let result: typeof singleResult.data
+  expectType<
+    TypeEqual<
+      typeof result,
+      {
+        Error: 'Type mismatch: Cannot cast array result to a single object. Use .returns<Array<YourType>> for array results or .single() to convert the result to a single object'
+      }
+    >
+  >(true)
+}
+
+// Test merge object result to array type should error
+{
+  const singleResult = await postgrest
+    .from('users')
+    .select()
+    .single()
+    .overrideTypes<{ custom_field: string }[]>()
+  if (singleResult.error) {
+    throw new Error(singleResult.error.message)
+  }
+  let result: typeof singleResult.data
+  expectType<
+    TypeEqual<
+      typeof result,
+      {
+        Error: 'Type mismatch: Cannot cast single object to array type. Remove Array wrapper from return type or make sure you are not using .single() up in the calling chain'
+      }
+    >
+  >(true)
+}
+
+// Test with single() / maybeSingle()
+{
+  const singleResult = await postgrest
+    .from('users')
+    .select()
+    .single()
+    .overrideTypes<{ custom_field: string }>()
+  if (singleResult.error) {
+    throw new Error(singleResult.error.message)
+  }
+  let result: typeof singleResult.data
+  expectType<TypeEqual<(typeof result)['custom_field'], string>>(true)
+}
+// Test with maybeSingle()
+{
+  const maybeSingleResult = await postgrest
+    .from('users')
+    .select()
+    .maybeSingle()
+    .overrideTypes<{ custom_field: string }>()
+  if (maybeSingleResult.error) {
+    throw new Error(maybeSingleResult.error.message)
+  }
+  let maybeSingleResultType: typeof maybeSingleResult.data
+  let expectedType: { custom_field: string } | null
+  expectType<TypeEqual<typeof maybeSingleResultType, typeof expectedType>>(true)
+}
+// Test replacing behavior
+{
+  const singleResult = await postgrest
+    .from('users')
+    .select()
+    .single()
+    .overrideTypes<{ custom_field: string }, { merge: false }>()
+  if (singleResult.error) {
+    throw new Error(singleResult.error.message)
+  }
+  let result: typeof singleResult.data
+  expectType<TypeEqual<typeof result, { custom_field: string }>>(true)
+}
+
+// Test with select()
+{
+  const singleResult = await postgrest
+    .from('users')
+    .select()
+    .overrideTypes<{ custom_field: string }[]>()
+  if (singleResult.error) {
+    throw new Error(singleResult.error.message)
+  }
+  let result: typeof singleResult.data
+  expectType<
+    TypeEqual<
+      typeof result,
+      {
+        username: string
+        data: CustomUserDataType | null
+        age_range: unknown
+        catchphrase: unknown
+        status: 'ONLINE' | 'OFFLINE' | null
+        custom_field: string
+      }[]
+    >
+  >(true)
+}
+// Test replacing select behavior
+{
+  const singleResult = await postgrest
+    .from('users')
+    .select()
+    .overrideTypes<{ custom_field: string }[], { merge: false }>()
+  if (singleResult.error) {
+    throw new Error(singleResult.error.message)
+  }
+  let result: typeof singleResult.data
+  expectType<TypeEqual<typeof result, { custom_field: string }[]>>(true)
+}


### PR DESCRIPTION
- Add `overrideTypes` method allow both partial and complete override of the return type, do partial override by default

@kamilogorek mentioned that we often had to port a lot of properties definition in order to override a single field when using `.returns` method.

This new method introduce a way to perform "partial override" per default, and allow the user to have similar behavior than the current `.returns` method by providing the option `{ merge: false }`.

This make this kind of type override where we only want to override `func_call` result easier to maintain.

**Before**:
```ts
const results = await getOrThrowTyped(
  readWriteNext
    .from('sometable')
    .select(
      'id, projects!projects_sometable_id_fkey(ref, name), func_call(id)'
    )
    .eq('slug', 'some-slug')
    .is('projects.metadata->base_project_id', null)
    .neq('projects.status', 'SOMEVALUE')
    .single()
    .returns<{
      id: number
      func_call?: { value: SomeEnum }
      projects: { ref: string; name: string }[]
    }>(),
  'Failed to retrieve infos'
)
```

**After**

```ts
const results = await getOrThrowTyped(
  readWriteNext
    .from('sometable')
    .select(
      'id, projects!projects_sometable_id_fkey(ref, name), func_call(id)'
    )
    .eq('slug', 'some-slug')
    .is('projects.metadata->base_project_id', null)
    .neq('projects.status', 'SOMEVALUE')
    .single()
    .overrideTypes<{
      // Here we can now override only the part that we are interested in
      func_call?: { value: SomeEnum }
    }>(),
  'Failed to retrieve infos'
)

// We can still opt out from the merging behavior with:
await getOrThrowTyped(
  readWriteNext
    .from('sometable')
    .select(
      'id, projects!projects_sometable_id_fkey(ref, name), func_call(id)'
    )
    .eq('slug', 'some-slug')
    .is('projects.metadata->base_project_id', null)
    .neq('projects.status', 'SOMEVALUE')
    .single()
    .overrideTypes<{
      id: number
      func_call?: { value: SomeEnum }
      projects: { ref: string; name: string }[]
    }, { merge: false }>(),
  'Failed to retrieve infos'
)
```