### PR TITLE
fix(types): overrideTypes work on invalid embeded relation

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -131,7 +131,9 @@ type Simplify<T> = T extends object ? { [K in keyof T]: T[K] } : T
 type MergeDeep<New, Row> = {
   [K in keyof New | keyof Row]: K extends keyof New
     ? K extends keyof Row
-      ? // Check if the override is on a embeded relation (array)
+      ? Row[K] extends SelectQueryError<string>
+        ? New[K]
+        : // Check if the override is on a embeded relation (array)
         New[K] extends any[]
         ? Row[K] extends any[]
           ? Array<Simplify<MergeDeep<NonNullable<New[K][number]>, NonNullable<Row[K][number]>>>>

--- a/test/override-types.test-d.ts
+++ b/test/override-types.test-d.ts
@@ -246,6 +246,7 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
           foo: number
           bar: { baz: number }
           en: 'ONE' | 'TWO' | 'THREE'
+          record: Record<string, Json | undefined> | null
           qux: boolean
         }
         age_range: unknown
@@ -275,6 +276,7 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
           foo: number
           bar: { baz: number }
           en: 'ONE' | 'TWO' | 'THREE'
+          record: Record<string, Json | undefined> | null
           qux: boolean
         } | null
         age_range: unknown
@@ -342,6 +344,38 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
           foo: string
           bar: { baz: number; newBaz: string }
           en: 'FOUR' // Overridden enum value
+          record: Record<string, Json | undefined> | null
+        }
+        age_range: unknown
+        catchphrase: unknown
+        status: 'ONLINE' | 'OFFLINE' | null
+      }[]
+    >
+  >(true)
+}
+
+// Test merging with Json defined as Record
+{
+  const result = await postgrest
+    .from('users')
+    .select()
+    .overrideTypes<{ data: { record: { baz: 'foo' } } }[]>()
+  if (result.error) {
+    throw new Error(result.error.message)
+  }
+  let data: typeof result.data
+  expectType<
+    TypeEqual<
+      typeof data,
+      {
+        username: string
+        data: {
+          foo: string
+          bar: {
+            baz: number
+          }
+          en: 'ONE' | 'TWO' | 'THREE'
+          record: { baz: 'foo' }
         }
         age_range: unknown
         catchphrase: unknown
@@ -500,32 +534,6 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
         catchphrase: unknown
         status: 'ONLINE' | 'OFFLINE' | null
         somerelation: { created_at: Date; data: string }
-      }[]
-    >
-  >(true)
-}
-
-// Test overrideTypes array object with error embeded relation
-{
-  const result = await postgrest.from('users').select('*, somerelation(*)').overrideTypes<
-    {
-      somerelation: { created_at: Date; data: string }[]
-    }[]
-  >()
-  if (result.error) {
-    throw new Error(result.error.message)
-  }
-  let data: typeof result.data
-  expectType<
-    TypeEqual<
-      typeof data,
-      {
-        username: string
-        data: CustomUserDataType | null
-        age_range: unknown
-        catchphrase: unknown
-        status: 'ONLINE' | 'OFFLINE' | null
-        somerelation: { created_at: Date; data: string }[]
       }[]
     >
   >(true)

--- a/test/override-types.test-d.ts
+++ b/test/override-types.test-d.ts
@@ -60,7 +60,7 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   let result: typeof singleResult.data
   expectType<TypeEqual<(typeof result)['custom_field'], string>>(true)
 }
-// Test with maybeSingle()
+// Test with maybeSingle() merging with new field
 {
   const maybeSingleResult = await postgrest
     .from('users')
@@ -71,7 +71,50 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
     throw new Error(maybeSingleResult.error.message)
   }
   let maybeSingleResultType: typeof maybeSingleResult.data
-  let expectedType: { custom_field: string } | null
+  let expectedType: {
+    age_range: unknown
+    catchphrase: unknown
+    data: CustomUserDataType | null
+    status: 'ONLINE' | 'OFFLINE' | null
+    username: string
+    custom_field: string
+  } | null
+  expectType<TypeEqual<typeof maybeSingleResultType, typeof expectedType>>(true)
+}
+// Test with maybeSingle() merging with override field
+{
+  const maybeSingleResult = await postgrest
+    .from('users')
+    .select()
+    .maybeSingle()
+    .overrideTypes<{ catchphrase: string }>()
+  if (maybeSingleResult.error) {
+    throw new Error(maybeSingleResult.error.message)
+  }
+  let maybeSingleResultType: typeof maybeSingleResult.data
+  let expectedType: {
+    age_range: unknown
+    catchphrase: string
+    data: CustomUserDataType | null
+    status: 'ONLINE' | 'OFFLINE' | null
+    username: string
+  } | null
+  expectType<TypeEqual<typeof maybeSingleResultType, typeof expectedType>>(true)
+}
+// Test with maybeSingle() replace with override field
+{
+  const maybeSingleResult = await postgrest
+    .from('users')
+    .select()
+    .maybeSingle()
+    .overrideTypes<{ catchphrase: string }, { merge: false }>()
+  if (maybeSingleResult.error) {
+    throw new Error(maybeSingleResult.error.message)
+  }
+  let maybeSingleResultType: typeof maybeSingleResult.data
+  let expectedType: {
+    catchphrase: string
+  } | null
   expectType<TypeEqual<typeof maybeSingleResultType, typeof expectedType>>(true)
 }
 // Test replacing behavior

--- a/test/override-types.test-d.ts
+++ b/test/override-types.test-d.ts
@@ -247,6 +247,7 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
           bar: { baz: number }
           en: 'ONE' | 'TWO' | 'THREE'
           record: Record<string, Json | undefined> | null
+          recordNumber: Record<number, Json | undefined> | null
           qux: boolean
         }
         age_range: unknown
@@ -277,6 +278,7 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
           bar: { baz: number }
           en: 'ONE' | 'TWO' | 'THREE'
           record: Record<string, Json | undefined> | null
+          recordNumber: Record<number, Json | undefined> | null
           qux: boolean
         } | null
         age_range: unknown
@@ -345,6 +347,7 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
           bar: { baz: number; newBaz: string }
           en: 'FOUR' // Overridden enum value
           record: Record<string, Json | undefined> | null
+          recordNumber: Record<number, Json | undefined> | null
         }
         age_range: unknown
         catchphrase: unknown
@@ -359,7 +362,7 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   const result = await postgrest
     .from('users')
     .select()
-    .overrideTypes<{ data: { record: { baz: 'foo' } } }[]>()
+    .overrideTypes<{ data: { record: { baz: 'foo' }; recordNumber: { bar: 'foo' } } }[]>()
   if (result.error) {
     throw new Error(result.error.message)
   }
@@ -375,7 +378,14 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
             baz: number
           }
           en: 'ONE' | 'TWO' | 'THREE'
-          record: { baz: 'foo' }
+          record: {
+            [x: string]: Json | undefined
+            baz: 'foo'
+          }
+          recordNumber: {
+            [x: number]: Json | undefined
+            bar: 'foo'
+          }
         }
         age_range: unknown
         catchphrase: unknown

--- a/test/override-types.test-d.ts
+++ b/test/override-types.test-d.ts
@@ -435,3 +435,55 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
     >
   >(true)
 }
+
+// Test overrideTypes single object with error embeded relation
+{
+  const result = await postgrest.from('users').select('*, somerelation(*)').overrideTypes<
+    {
+      somerelation: { created_at: Date; data: string }
+    }[]
+  >()
+  if (result.error) {
+    throw new Error(result.error.message)
+  }
+  let data: typeof result.data
+  expectType<
+    TypeEqual<
+      typeof data,
+      {
+        username: string
+        data: CustomUserDataType | null
+        age_range: unknown
+        catchphrase: unknown
+        status: 'ONLINE' | 'OFFLINE' | null
+        somerelation: { created_at: Date; data: string }
+      }[]
+    >
+  >(true)
+}
+
+// Test overrideTypes array object with error embeded relation
+{
+  const result = await postgrest.from('users').select('*, somerelation(*)').overrideTypes<
+    {
+      somerelation: { created_at: Date; data: string }[]
+    }[]
+  >()
+  if (result.error) {
+    throw new Error(result.error.message)
+  }
+  let data: typeof result.data
+  expectType<
+    TypeEqual<
+      typeof data,
+      {
+        username: string
+        data: CustomUserDataType | null
+        age_range: unknown
+        catchphrase: unknown
+        status: 'ONLINE' | 'OFFLINE' | null
+        somerelation: { created_at: Date; data: string }[]
+      }[]
+    >
+  >(true)
+}

--- a/test/types.ts
+++ b/test/types.ts
@@ -6,6 +6,7 @@ export type CustomUserDataType = {
     baz: number
   }
   en: 'ONE' | 'TWO' | 'THREE'
+  record: Record<string, Json | undefined> | null
 }
 
 export type Database = {

--- a/test/types.ts
+++ b/test/types.ts
@@ -7,6 +7,7 @@ export type CustomUserDataType = {
   }
   en: 'ONE' | 'TWO' | 'THREE'
   record: Record<string, Json | undefined> | null
+  recordNumber: Record<number, Json | undefined> | null
 }
 
 export type Database = {


### PR DESCRIPTION
- When a relation doesn't exist, or that type inference fail to resolve it the new type should be the source of truth for the result. In such case, we don't "merge" the properties together, but just replace the error with the user provided type.
- When chaining the override with `.maybeSingle` preserve the optionality of the result
- Allow merging between literal object and non literal one eg:
```ts
// Given some property like
{
   someProperty: Record<string, Json | null>
}
// calling
overrideType<{ someProperty: { literalProperty: string }  }>()
// result in:
{
    [key: string]: Json | null
    someProperty: { literalProperty: string }
} 
```
