### PR TITLE
fix(types): outdated error message

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -114,7 +114,7 @@ export type CheckMatchingArrayTypes<Result, NewResult> =
         Result,
         NewResult,
         {
-          Error: 'Type mismatch: Cannot cast array result to a single object. Use .returns<Array<YourType>> for array results or .single() to convert the result to a single object'
+          Error: 'Type mismatch: Cannot cast array result to a single object. Use .overrideTypes<Array<YourType>> or .returns<Array<YourType>> (deprecated) for array results or .single() to convert the result to a single object'
         },
         {
           Error: 'Type mismatch: Cannot cast single object to array type. Remove Array wrapper from return type or make sure you are not using .single() up in the calling chain'

--- a/test/override-types.test-d.ts
+++ b/test/override-types.test-d.ts
@@ -20,7 +20,7 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
     TypeEqual<
       typeof result,
       {
-        Error: 'Type mismatch: Cannot cast array result to a single object. Use .returns<Array<YourType>> for array results or .single() to convert the result to a single object'
+        Error: 'Type mismatch: Cannot cast array result to a single object. Use .overrideTypes<Array<YourType>> or .returns<Array<YourType>> (deprecated) for array results or .single() to convert the result to a single object'
       }
     >
   >(true)

--- a/test/returns.test-d.ts
+++ b/test/returns.test-d.ts
@@ -41,7 +41,7 @@ const postgrest = new PostgrestClient<Database>(REST_URL)
   }
   let resultType: typeof invalidCastArray.data
   let resultExpected: {
-    Error: 'Type mismatch: Cannot cast array result to a single object. Use .returns<Array<YourType>> for array results or .single() to convert the result to a single object'
+    Error: 'Type mismatch: Cannot cast array result to a single object. Use .overrideTypes<Array<YourType>> or .returns<Array<YourType>> (deprecated) for array results or .single() to convert the result to a single object'
   }
   expectType<TypeEqual<typeof resultType, typeof resultExpected>>(true)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Slightly changes the output of the error, as when using:
`.overrideTypes<MyType>()`
for an array of results - I was getting error pointing me to use `.returns<Array<YourType>>` which is currently deprecated. 

I've made a message clear for users that gets this error from `.overrideTypes` as well as for `.returns` enjoyers. 

## What is the current behavior?

It returns an error message that can be misleading and pointing to use deprecated features.

## What is the new behavior?



## Additional context

Add any other context or screenshots.
