### PR TITLE
chore(tests): setup zod type checking unify

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,9 @@ module.exports = {
   maxWorkers: 1,
   // Ensure deterministic test order
   testSequencer: '<rootDir>/test/testSequencer.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.test.json'
+    }
+  }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,8 @@ module.exports = {
   // Ensure deterministic test order
   testSequencer: '<rootDir>/test/testSequencer.js',
   globals: {
+    // For consistency between VSCode and type-check
+    // https://github.com/supabase/postgrest-js/pull/627#discussion_r2236995331
     'ts-jest': {
       tsconfig: 'tsconfig.test.json'
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "type-fest": "^4.32.0",
         "typedoc": "^0.22.16",
         "typescript": "^4.5.5",
-        "wait-for-localhost-cli": "^3.0.0"
+        "wait-for-localhost-cli": "^3.0.0",
+        "zod": "^3.25.76"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1646,10 +1647,11 @@
       ]
     },
     "node_modules/chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1899,13 +1901,13 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -4231,10 +4233,11 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -6206,6 +6209,16 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -7473,9 +7486,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
@@ -7656,12 +7669,12 @@
       }
     },
     "debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       }
     },
     "decamelize": {
@@ -9385,9 +9398,9 @@
       }
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "natural-compare": {
@@ -10787,6 +10800,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
+    },
+    "zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "test:update": "run-s db:clean db:run db:generate-test-types && jest --runInBand --updateSnapshot && run-s db:clean",
     "test:types": "run-s build && tsd --files 'test/**/*.test-d.ts'",
     "test:types:watch": "run-s build && tsd --files 'test/**/*.test-d.ts' --watch",
+    "type-check": "tsc --noEmit --project tsconfig.json",
+    "type-check:test": "tsc --noEmit --project tsconfig.test.json",
     "db:clean": "cd test/db && docker compose down --volumes",
     "db:run": "cd test/db && docker compose up --detach && wait-for-localhost 3000",
     "db:generate-test-types": "cd test/db && docker compose up --detach && wait-for-localhost 8080 && curl --location 'http://0.0.0.0:8080/generators/typescript?included_schemas=public,personal&detect_one_to_one_relationships=true' > ../types.generated.ts && sed -i '' 's/export type Json = .*/export type Json = unknown;/' ../types.generated.ts"
@@ -64,6 +66,7 @@
     "type-fest": "^4.32.0",
     "typedoc": "^0.22.16",
     "typescript": "^4.5.5",
-    "wait-for-localhost-cli": "^3.0.0"
+    "wait-for-localhost-cli": "^3.0.0",
+    "zod": "^3.25.76"
   }
 }

--- a/src/select-query-parser/result.ts
+++ b/src/select-query-parser/result.ts
@@ -205,7 +205,8 @@ export type ProcessNodes<
                 RelationName,
                 Relationships,
                 RestNodes,
-                Acc & FieldResult
+                // Replace fields that exist in both Acc and FieldResult instead of intersecting
+                Omit<Acc, keyof FieldResult> & FieldResult
               >
             : FieldResult extends SelectQueryError<infer E>
             ? SelectQueryError<E>

--- a/test/relationships-join-operations.test.ts
+++ b/test/relationships-join-operations.test.ts
@@ -528,11 +528,12 @@ test('join over a 1-M relation with both nullables and non-nullables fields usin
     }
   `)
   let result: Exclude<typeof res.data, null>
-  type ExpectedType = Prettify<
-    Database['public']['Tables']['best_friends']['Row'] & {
-      first_user: string & Database['public']['Tables']['users']['Row']
-    }
-  >
+  type ExpectedType = {
+    id: number
+    first_user: Database['public']['Tables']['users']['Row']
+    second_user: string
+    third_wheel: string | null
+  }
   let expected: {
     first_friend_of: ExpectedType[]
     second_friend_of: Array<Database['public']['Tables']['best_friends']['Row']>

--- a/test/types.override.ts
+++ b/test/types.override.ts
@@ -1,15 +1,19 @@
 import type { Database as GeneratedDatabase } from './types.generated'
 import { MergeDeep } from 'type-fest'
 
-export type CustomUserDataType = {
-  foo: string
-  bar: {
-    baz: number
-  }
-  en: 'ONE' | 'TWO' | 'THREE'
-  record: Record<string, unknown> | null
-  recordNumber: Record<number, unknown> | null
-}
+import { z } from 'zod'
+
+export const CustomUserDataTypeSchema = z.object({
+  foo: z.string(),
+  bar: z.object({
+    baz: z.number(),
+  }),
+  en: z.enum(['ONE', 'TWO', 'THREE']),
+  record: z.record(z.string(), z.unknown()).nullable(),
+  recordNumber: z.record(z.number(), z.unknown()).nullable(),
+})
+
+export type CustomUserDataType = z.infer<typeof CustomUserDataTypeSchema>
 
 export type Database = MergeDeep<
   GeneratedDatabase,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "test"],
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "skipLibCheck": true,
+    "module": "ES2022",
+    "target": "ES2022"
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Still in the idea to make a more straightforward, unified and strongly typed values for our tests: 

- Introduce `zod` schemas and re-use the same schemas to both:
  - infer the expected result type
  - Ensure that the runtime result type match the validation of the schema

- Doing so, found a bug where self-referencing embeding via columns name would cause an unwanted intersection and fixed it.