### PR TITLE
chore(tests): add zod schema validation to more tests

### DIFF
--- a/test/relationships-aggregate-operations.test.ts
+++ b/test/relationships-aggregate-operations.test.ts
@@ -2,6 +2,7 @@ import { PostgrestClient } from '../src/index'
 import { Database } from './types.override'
 import { expectType } from 'tsd'
 import { TypeEqual } from 'ts-expect'
+import { z } from 'zod'
 
 const REST_URL = 'http://localhost:3000'
 export const postgrest = new PostgrestClient<Database>(REST_URL)
@@ -25,13 +26,17 @@ test('select with aggregate count function', async () => {
       }
     `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    username: string
-    messages: Array<{
-      count: number
-    }>
-  }
+  const ExpectedSchema = z.object({
+    username: z.string(),
+    messages: z.array(
+      z.object({
+        count: z.number(),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('select with aggregate count on a column function', async () => {
@@ -57,13 +62,17 @@ test('select with aggregate count on a column function', async () => {
       }
     `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    username: string
-    messages: Array<{
-      count: number
-    }>
-  }
+  const ExpectedSchema = z.object({
+    username: z.string(),
+    messages: z.array(
+      z.object({
+        count: z.number(),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('select with aggregate count function and alias', async () => {
@@ -89,13 +98,17 @@ test('select with aggregate count function and alias', async () => {
       }
     `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    username: string
-    messages: Array<{
-      message_count: number
-    }>
-  }
+  const ExpectedSchema = z.object({
+    username: z.string(),
+    messages: z.array(
+      z.object({
+        message_count: z.number(),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('select with aggregate nested count function', async () => {
@@ -133,15 +146,19 @@ test('select with aggregate nested count function', async () => {
       }
     `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    username: string
-    messages: Array<{
-      channels: {
-        count: number
-      }
-    }>
-  }
+  const ExpectedSchema = z.object({
+    username: z.string(),
+    messages: z.array(
+      z.object({
+        channels: z.object({
+          count: z.number(),
+        }),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('select with aggregate nested count function and alias', async () => {
@@ -179,15 +196,19 @@ test('select with aggregate nested count function and alias', async () => {
       }
     `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    username: string
-    messages: Array<{
-      channels: {
-        channel_count: number
-      }
-    }>
-  }
+  const ExpectedSchema = z.object({
+    username: z.string(),
+    messages: z.array(
+      z.object({
+        channels: z.object({
+          channel_count: z.number(),
+        }),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('select with aggregate sum function', async () => {
@@ -209,13 +230,17 @@ test('select with aggregate sum function', async () => {
       }
     `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    username: string
-    messages: Array<{
-      sum: number
-    }>
-  }
+  const ExpectedSchema = z.object({
+    username: z.string(),
+    messages: z.array(
+      z.object({
+        sum: z.number(),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('select with aggregate aliased sum function', async () => {
@@ -241,13 +266,17 @@ test('select with aggregate aliased sum function', async () => {
       }
     `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    username: string
-    messages: Array<{
-      sum_id: number
-    }>
-  }
+  const ExpectedSchema = z.object({
+    username: z.string(),
+    messages: z.array(
+      z.object({
+        sum_id: z.number(),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('select with aggregate sum function on nested relation', async () => {
@@ -285,13 +314,17 @@ test('select with aggregate sum function on nested relation', async () => {
       }
     `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    username: string
-    messages: Array<{
-      channels: {
-        sum: number
-      }
-    }>
-  }
+  const ExpectedSchema = z.object({
+    username: z.string(),
+    messages: z.array(
+      z.object({
+        channels: z.object({
+          sum: z.number(),
+        }),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })

--- a/test/relationships-spread-operations.test.ts
+++ b/test/relationships-spread-operations.test.ts
@@ -3,6 +3,7 @@ import { Database } from './types.override'
 import { Database as DatabaseWithOptions13 } from './types.override-with-options-postgrest13'
 import { expectType } from 'tsd'
 import { TypeEqual } from 'ts-expect'
+import { z } from 'zod'
 
 const REST_URL = 'http://localhost:3000'
 export const postgrest = new PostgrestClient<Database>(REST_URL)
@@ -48,16 +49,20 @@ test('select with aggregate count and spread', async () => {
     }
   `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    username: string
-    messages: Array<{
-      channels: {
-        count: number
-        details: string | null
-      }
-    }>
-  }
+  const ExpectedSchema = z.object({
+    username: z.string(),
+    messages: z.array(
+      z.object({
+        channels: z.object({
+          count: z.number(),
+          details: z.string().nullable(),
+        }),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('spread resource with single column in select query', async () => {
@@ -98,16 +103,20 @@ test('spread resource with single column in select query', async () => {
     }
   `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    username: string
-    messages: Array<{
-      channels: {
-        count: number
-        details: string | null
-      }
-    }>
-  }
+  const ExpectedSchema = z.object({
+    username: z.string(),
+    messages: z.array(
+      z.object({
+        channels: z.object({
+          count: z.number(),
+          details: z.string().nullable(),
+        }),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('spread resource with all columns in select query', async () => {
@@ -151,17 +160,21 @@ test('spread resource with all columns in select query', async () => {
     }
   `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    username: string
-    messages: Array<{
-      channels: {
-        count: number
-        details: string | null
-        id: number | null
-      }
-    }>
-  }
+  const ExpectedSchema = z.object({
+    username: z.string(),
+    messages: z.array(
+      z.object({
+        channels: z.object({
+          count: z.number(),
+          details: z.string().nullable(),
+          id: z.number().nullable(),
+        }),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('select with aggregate sum and spread', async () => {
@@ -202,16 +215,20 @@ test('select with aggregate sum and spread', async () => {
     }
   `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    username: string
-    messages: Array<{
-      channels: {
-        sum: number
-        details: string | null
-      }
-    }>
-  }
+  const ExpectedSchema = z.object({
+    username: z.string(),
+    messages: z.array(
+      z.object({
+        channels: z.object({
+          sum: z.number(),
+          details: z.string().nullable(),
+        }),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('select with aggregate sum and spread on nested relation', async () => {
@@ -257,17 +274,21 @@ test('select with aggregate sum and spread on nested relation', async () => {
     }
   `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    username: string
-    messages: Array<{
-      channels: {
-        sum: number
-        details_sum: number | null
-        details: string | null
-      }
-    }>
-  }
+  const ExpectedSchema = z.object({
+    username: z.string(),
+    messages: z.array(
+      z.object({
+        channels: z.object({
+          sum: z.number(),
+          details_sum: z.number().nullable(),
+          details: z.string().nullable(),
+        }),
+      })
+    ),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('select with spread on nested relation', async () => {
@@ -293,15 +314,17 @@ test('select with spread on nested relation', async () => {
     }
   `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    id: number
-    channels: {
-      id: number
-      details_id: number | null
-      details: string | null
-    }
-  }
+  const ExpectedSchema = z.object({
+    id: z.number(),
+    channels: z.object({
+      id: z.number(),
+      details_id: z.number().nullable(),
+      details: z.string().nullable(),
+    }),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('select spread on many relation postgrest13', async () => {
@@ -328,12 +351,14 @@ test('select spread on many relation postgrest13', async () => {
     }
   `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    channel_id: number
-    id: Array<number>
-    message: Array<string | null>
-  }
+  const ExpectedSchema = z.object({
+    channel_id: z.number(),
+    id: z.array(z.number()),
+    message: z.array(z.string().nullable()),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('select spread on many relation postgrest13FromDatabaseTypes', async () => {
@@ -360,10 +385,12 @@ test('select spread on many relation postgrest13FromDatabaseTypes', async () => 
     }
   `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    channel_id: number
-    id: Array<number>
-    message: Array<string | null>
-  }
+  const ExpectedSchema = z.object({
+    channel_id: z.number(),
+    id: z.array(z.number()),
+    message: z.array(z.string().nullable()),
+  })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })

--- a/test/relationships.test.ts
+++ b/test/relationships.test.ts
@@ -4,6 +4,7 @@ import { expectType } from 'tsd'
 import { TypeEqual } from 'ts-expect'
 import { z } from 'zod'
 import { Json } from '../src/select-query-parser/types'
+import { RequiredDeep } from 'type-fest'
 
 const REST_URL = 'http://localhost:3000'
 export const postgrest = new PostgrestClient<Database>(REST_URL)
@@ -52,6 +53,7 @@ test('nested query with selective fields', async () => {
       "statusText": "OK",
     }
   `)
+  let result: Exclude<typeof res.data, null>
   const ExpectedSchema = z.object({
     username: z.string(),
     messages: z.array(
@@ -61,9 +63,7 @@ test('nested query with selective fields', async () => {
       })
     ),
   })
-  type ExpectedType = z.infer<typeof ExpectedSchema>
-  let result: Exclude<typeof res.data, null>
-  let expected: ExpectedType
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -111,6 +111,7 @@ test('nested query with multiple levels and selective fields', async () => {
       "statusText": "OK",
     }
   `)
+  let result: Exclude<typeof res.data, null>
   const ExpectedSchema = z.object({
     username: z.string(),
     messages: z.array(
@@ -124,9 +125,7 @@ test('nested query with multiple levels and selective fields', async () => {
       })
     ),
   })
-  type ExpectedType = z.infer<typeof ExpectedSchema>
-  let result: Exclude<typeof res.data, null>
-  let expected: ExpectedType
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -164,14 +163,13 @@ test('query with multiple one-to-many relationships', async () => {
       "statusText": "OK",
     }
   `)
+  let result: Exclude<typeof res.data, null>
   const ExpectedSchema = z.object({
     username: z.string(),
     messages: z.array(z.object({ id: z.number() })),
     user_profiles: z.array(z.object({ id: z.number() })),
   })
-  type ExpectedType = z.infer<typeof ExpectedSchema>
-  let result: Exclude<typeof res.data, null>
-  let expected: ExpectedType
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -195,14 +193,11 @@ test('many-to-one relationship', async () => {
       "statusText": "OK",
     }
   `)
+  let result: Exclude<typeof res.data, null>
   const ExpectedSchema = z.object({
     user: UsersRowSchema,
   })
-  let result: Exclude<typeof res.data, null>
-  // TODO: zod schema inference with status enum fail to properly pass the type test
-  let expected: {
-    user: Database['public']['Tables']['users']['Row']
-  }
+  let expected: RequiredDeep<z.infer<typeof ExpectedSchema>>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -242,6 +237,7 @@ test('one-to-many relationship', async () => {
       "statusText": "OK",
     }
   `)
+  let result: Exclude<typeof res.data, null>
   const ExpectedSchema = z.object({
     messages: z.array(
       z.object({
@@ -253,11 +249,9 @@ test('one-to-many relationship', async () => {
       })
     ),
   })
-  type ExpectedType = z.infer<typeof ExpectedSchema>
-  let result: Exclude<typeof res.data, null>
   // TODO: older versions of zod require this trick for non optional unknown data type
   // newer version of zod don't have this issue but require an upgrade of typescript minimal version
-  let expected: { messages: Array<Required<ExpectedType['messages'][number]>> }
+  let expected: RequiredDeep<z.infer<typeof ExpectedSchema>>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -285,14 +279,13 @@ test('one-to-many relationship with selective columns', async () => {
       "statusText": "OK",
     }
   `)
+  let result: Exclude<typeof res.data, null>
   const ExpectedSchema = z.object({
     messages: z.array(z.object({ data: z.unknown().nullable() })),
   })
-  type ExpectedType = z.infer<typeof ExpectedSchema>
-  let result: Exclude<typeof res.data, null>
   // TODO: older versions of zod require this trick for non optional unknown data type
   // newer version of zod don't have this issue but require an upgrade of typescript minimal version
-  let expected: { messages: Array<Required<ExpectedType['messages'][number]>> }
+  let expected: RequiredDeep<z.infer<typeof ExpectedSchema>>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -313,12 +306,11 @@ test('one-to-one relationship', async () => {
       "statusText": "OK",
     }
   `)
+  let result: Exclude<typeof res.data, null>
   const ExpectedSchema = z.object({
     channel_details: ChannelDetailsRowSchema.nullable(),
   })
-  type ExpectedType = z.infer<typeof ExpectedSchema>
-  let result: Exclude<typeof res.data, null>
-  let expected: ExpectedType
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -336,10 +328,9 @@ test('select with type casting query', async () => {
       "statusText": "OK",
     }
   `)
-  const ExpectedSchema = z.object({ id: z.string() })
-  type ExpectedType = z.infer<typeof ExpectedSchema>
   let result: Exclude<typeof res.data, null>
-  let expected: ExpectedType
+  const ExpectedSchema = z.object({ id: z.string() })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -357,10 +348,9 @@ test('multiple times the same column in selection', async () => {
       "statusText": "OK",
     }
   `)
-  const ExpectedSchema = z.object({ id: z.number() })
-  type ExpectedType = z.infer<typeof ExpectedSchema>
   let result: Exclude<typeof res.data, null>
-  let expected: ExpectedType
+  const ExpectedSchema = z.object({ id: z.number() })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -378,10 +368,9 @@ test('embed resource with no fields', async () => {
       "statusText": "OK",
     }
   `)
-  const ExpectedSchema = z.object({ message: z.string().nullable() })
-  type ExpectedType = z.infer<typeof ExpectedSchema>
   let result: Exclude<typeof res.data, null>
-  let expected: ExpectedType
+  const ExpectedSchema = z.object({ message: z.string().nullable() })
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -407,11 +396,11 @@ test('select JSON accessor', async () => {
       "statusText": "OK",
     }
   `)
+  let result: Exclude<typeof res.data, null>
   const ExpectedSchema = z.object({
     bar: z.unknown(),
     baz: z.string(),
   })
-  let result: Exclude<typeof res.data, null>
   // Cannot have a zod schema that match the Json type
   // TODO: refactor the Json type to be unknown
   let expected: {
@@ -449,6 +438,7 @@ test('self reference relation', async () => {
       "statusText": "OK",
     }
   `)
+  let result: Exclude<typeof res.data, null>
   const ExpectedSchema = z.object({
     id: z.number(),
     description: z.string().nullable(),
@@ -461,9 +451,7 @@ test('self reference relation', async () => {
       })
     ),
   })
-  type ExpectedType = z.infer<typeof ExpectedSchema>
-  let result: Exclude<typeof res.data, null>
-  let expected: ExpectedType
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -492,6 +480,7 @@ test('self reference relation via column', async () => {
       "statusText": "OK",
     }
   `)
+  let result: Exclude<typeof res.data, null>
   const ExpectedSchema = z.object({
     description: z.string().nullable(),
     id: z.number(),
@@ -503,9 +492,7 @@ test('self reference relation via column', async () => {
       })
       .nullable(),
   })
-  type ExpectedType = z.infer<typeof ExpectedSchema>
-  let result: Exclude<typeof res.data, null>
-  let expected: ExpectedType
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -538,6 +525,7 @@ test('many-to-many with join table', async () => {
       "statusText": "OK",
     }
   `)
+  let result: Exclude<typeof res.data, null>
   const ExpectedSchema = z.object({
     id: z.number(),
     name: z.string(),
@@ -551,9 +539,7 @@ test('many-to-many with join table', async () => {
       })
     ),
   })
-  type ExpectedType = z.infer<typeof ExpectedSchema>
-  let result: Exclude<typeof res.data, null>
-  let expected: ExpectedType
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })

--- a/test/resource-embedding.test.ts
+++ b/test/resource-embedding.test.ts
@@ -3,6 +3,7 @@ import { Database } from './types.override'
 import { expectType } from 'tsd'
 import { TypeEqual } from 'ts-expect'
 import { z } from 'zod'
+import { RequiredDeep } from 'type-fest'
 
 const postgrest = new PostgrestClient<Database>('http://localhost:3000')
 
@@ -70,8 +71,9 @@ test('embedded select', async () => {
       ),
     })
   )
-  type ExpectedType = z.infer<typeof ExpectedSchema>
-  let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
+  // TODO: older versions of zod require this trick for non optional unknown data type
+  // newer version of zod don't have this issue but require an upgrade of typescript minimal version
+  let expected: RequiredDeep<z.infer<typeof ExpectedSchema>>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -144,8 +146,9 @@ test('embedded select with computed field explicit selection', async () => {
       ),
     })
   )
-  type ExpectedType = z.infer<typeof ExpectedSchema>
-  let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
+  // TODO: older versions of zod require this trick for non optional unknown data type
+  // newer version of zod don't have this issue but require an upgrade of typescript minimal version
+  let expected: RequiredDeep<z.infer<typeof ExpectedSchema>>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
   ExpectedSchema.parse(res.data)
 })
@@ -204,8 +207,9 @@ describe('embedded filters', () => {
         ),
       })
     )
-    type ExpectedType = z.infer<typeof ExpectedSchema>
-    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
+    // TODO: older versions of zod require this trick for non optional unknown data type
+    // newer version of zod don't have this issue but require an upgrade of typescript minimal version
+    let expected: RequiredDeep<z.infer<typeof ExpectedSchema>>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
     ExpectedSchema.parse(res.data)
   })
@@ -268,8 +272,9 @@ describe('embedded filters', () => {
         ),
       })
     )
-    type ExpectedType = z.infer<typeof ExpectedSchema>
-    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
+    // TODO: older versions of zod require this trick for non optional unknown data type
+    // newer version of zod don't have this issue but require an upgrade of typescript minimal version
+    let expected: RequiredDeep<z.infer<typeof ExpectedSchema>>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
     ExpectedSchema.parse(res.data)
   })
@@ -334,8 +339,9 @@ describe('embedded filters', () => {
         ),
       })
     )
-    type ExpectedType = z.infer<typeof ExpectedSchema>
-    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
+    // TODO: older versions of zod require this trick for non optional unknown data type
+    // newer version of zod don't have this issue but require an upgrade of typescript minimal version
+    let expected: RequiredDeep<z.infer<typeof ExpectedSchema>>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
     ExpectedSchema.parse(res.data)
   })
@@ -408,8 +414,9 @@ describe('embedded transforms', () => {
         ),
       })
     )
-    type ExpectedType = z.infer<typeof ExpectedSchema>
-    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
+    // TODO: older versions of zod require this trick for non optional unknown data type
+    // newer version of zod don't have this issue but require an upgrade of typescript minimal version
+    let expected: RequiredDeep<z.infer<typeof ExpectedSchema>>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
     ExpectedSchema.parse(res.data)
   })
@@ -481,8 +488,9 @@ describe('embedded transforms', () => {
         ),
       })
     )
-    type ExpectedType = z.infer<typeof ExpectedSchema>
-    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
+    // TODO: older versions of zod require this trick for non optional unknown data type
+    // newer version of zod don't have this issue but require an upgrade of typescript minimal version
+    let expected: RequiredDeep<z.infer<typeof ExpectedSchema>>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
     ExpectedSchema.parse(res.data)
   })
@@ -539,8 +547,9 @@ describe('embedded transforms', () => {
         ),
       })
     )
-    type ExpectedType = z.infer<typeof ExpectedSchema>
-    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
+    // TODO: older versions of zod require this trick for non optional unknown data type
+    // newer version of zod don't have this issue but require an upgrade of typescript minimal version
+    let expected: RequiredDeep<z.infer<typeof ExpectedSchema>>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
     ExpectedSchema.parse(res.data)
   })
@@ -597,8 +606,9 @@ describe('embedded transforms', () => {
         ),
       })
     )
-    type ExpectedType = z.infer<typeof ExpectedSchema>
-    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
+    // TODO: older versions of zod require this trick for non optional unknown data type
+    // newer version of zod don't have this issue but require an upgrade of typescript minimal version
+    let expected: RequiredDeep<z.infer<typeof ExpectedSchema>>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
     ExpectedSchema.parse(res.data)
   })

--- a/test/resource-embedding.test.ts
+++ b/test/resource-embedding.test.ts
@@ -2,6 +2,7 @@ import { PostgrestClient } from '../src/index'
 import { Database } from './types.override'
 import { expectType } from 'tsd'
 import { TypeEqual } from 'ts-expect'
+import { z } from 'zod'
 
 const postgrest = new PostgrestClient<Database>('http://localhost:3000')
 
@@ -56,16 +57,23 @@ test('embedded select', async () => {
     }
   `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    messages: {
-      channel_id: number
-      data: unknown
-      id: number
-      message: string | null
-      username: string
-    }[]
-  }[]
+  const ExpectedSchema = z.array(
+    z.object({
+      messages: z.array(
+        z.object({
+          channel_id: z.number(),
+          data: z.unknown().nullable(),
+          id: z.number(),
+          message: z.string().nullable(),
+          username: z.string(),
+        })
+      ),
+    })
+  )
+  type ExpectedType = z.infer<typeof ExpectedSchema>
+  let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('embedded select with computed field explicit selection', async () => {
@@ -122,17 +130,24 @@ test('embedded select with computed field explicit selection', async () => {
     }
   `)
   let result: Exclude<typeof res.data, null>
-  let expected: {
-    messages: {
-      channel_id: number
-      data: unknown
-      id: number
-      message: string | null
-      username: string
-      blurb_message: string | null
-    }[]
-  }[]
+  const ExpectedSchema = z.array(
+    z.object({
+      messages: z.array(
+        z.object({
+          channel_id: z.number(),
+          data: z.unknown().nullable(),
+          id: z.number(),
+          message: z.string().nullable(),
+          username: z.string(),
+          blurb_message: z.string().nullable(),
+        })
+      ),
+    })
+  )
+  type ExpectedType = z.infer<typeof ExpectedSchema>
+  let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 describe('embedded filters', () => {
@@ -176,16 +191,23 @@ describe('embedded filters', () => {
       }
     `)
     let result: Exclude<typeof res.data, null>
-    let expected: {
-      messages: {
-        channel_id: number
-        data: unknown
-        id: number
-        message: string | null
-        username: string
-      }[]
-    }[]
+    const ExpectedSchema = z.array(
+      z.object({
+        messages: z.array(
+          z.object({
+            channel_id: z.number(),
+            data: z.unknown().nullable(),
+            id: z.number(),
+            message: z.string().nullable(),
+            username: z.string(),
+          })
+        ),
+      })
+    )
+    type ExpectedType = z.infer<typeof ExpectedSchema>
+    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
+    ExpectedSchema.parse(res.data)
   })
   test('embedded or', async () => {
     const res = await postgrest
@@ -233,16 +255,23 @@ describe('embedded filters', () => {
       }
     `)
     let result: Exclude<typeof res.data, null>
-    let expected: {
-      messages: {
-        channel_id: number
-        data: unknown
-        id: number
-        message: string | null
-        username: string
-      }[]
-    }[]
+    const ExpectedSchema = z.array(
+      z.object({
+        messages: z.array(
+          z.object({
+            channel_id: z.number(),
+            data: z.unknown().nullable(),
+            id: z.number(),
+            message: z.string().nullable(),
+            username: z.string(),
+          })
+        ),
+      })
+    )
+    type ExpectedType = z.infer<typeof ExpectedSchema>
+    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
+    ExpectedSchema.parse(res.data)
   })
   test('embedded or with and', async () => {
     const res = await postgrest
@@ -292,16 +321,23 @@ describe('embedded filters', () => {
       }
     `)
     let result: Exclude<typeof res.data, null>
-    let expected: {
-      messages: {
-        channel_id: number
-        data: unknown
-        id: number
-        message: string | null
-        username: string
-      }[]
-    }[]
+    const ExpectedSchema = z.array(
+      z.object({
+        messages: z.array(
+          z.object({
+            channel_id: z.number(),
+            data: z.unknown().nullable(),
+            id: z.number(),
+            message: z.string().nullable(),
+            username: z.string(),
+          })
+        ),
+      })
+    )
+    type ExpectedType = z.infer<typeof ExpectedSchema>
+    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
+    ExpectedSchema.parse(res.data)
   })
 })
 
@@ -359,16 +395,23 @@ describe('embedded transforms', () => {
       }
     `)
     let result: Exclude<typeof res.data, null>
-    let expected: {
-      messages: {
-        channel_id: number
-        data: unknown
-        id: number
-        message: string | null
-        username: string
-      }[]
-    }[]
+    const ExpectedSchema = z.array(
+      z.object({
+        messages: z.array(
+          z.object({
+            channel_id: z.number(),
+            data: z.unknown().nullable(),
+            id: z.number(),
+            message: z.string().nullable(),
+            username: z.string(),
+          })
+        ),
+      })
+    )
+    type ExpectedType = z.infer<typeof ExpectedSchema>
+    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
+    ExpectedSchema.parse(res.data)
   })
 
   test('embedded order on multiple columns', async () => {
@@ -425,16 +468,23 @@ describe('embedded transforms', () => {
       }
     `)
     let result: Exclude<typeof res.data, null>
-    let expected: {
-      messages: {
-        channel_id: number
-        data: unknown
-        id: number
-        message: string | null
-        username: string
-      }[]
-    }[]
+    const ExpectedSchema = z.array(
+      z.object({
+        messages: z.array(
+          z.object({
+            channel_id: z.number(),
+            data: z.unknown().nullable(),
+            id: z.number(),
+            message: z.string().nullable(),
+            username: z.string(),
+          })
+        ),
+      })
+    )
+    type ExpectedType = z.infer<typeof ExpectedSchema>
+    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
+    ExpectedSchema.parse(res.data)
   })
 
   test('embedded limit', async () => {
@@ -476,16 +526,23 @@ describe('embedded transforms', () => {
       }
     `)
     let result: Exclude<typeof res.data, null>
-    let expected: {
-      messages: {
-        channel_id: number
-        data: unknown
-        id: number
-        message: string | null
-        username: string
-      }[]
-    }[]
+    const ExpectedSchema = z.array(
+      z.object({
+        messages: z.array(
+          z.object({
+            channel_id: z.number(),
+            data: z.unknown().nullable(),
+            id: z.number(),
+            message: z.string().nullable(),
+            username: z.string(),
+          })
+        ),
+      })
+    )
+    type ExpectedType = z.infer<typeof ExpectedSchema>
+    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
+    ExpectedSchema.parse(res.data)
   })
 
   test('embedded range', async () => {
@@ -527,15 +584,22 @@ describe('embedded transforms', () => {
       }
     `)
     let result: Exclude<typeof res.data, null>
-    let expected: {
-      messages: {
-        channel_id: number
-        data: unknown
-        id: number
-        message: string | null
-        username: string
-      }[]
-    }[]
+    const ExpectedSchema = z.array(
+      z.object({
+        messages: z.array(
+          z.object({
+            channel_id: z.number(),
+            data: z.unknown().nullable(),
+            id: z.number(),
+            message: z.string().nullable(),
+            username: z.string(),
+          })
+        ),
+      })
+    )
+    type ExpectedType = z.infer<typeof ExpectedSchema>
+    let expected: Array<{ messages: Array<Required<ExpectedType[number]['messages'][number]>> }>
     expectType<TypeEqual<typeof result, typeof expected>>(true)
+    ExpectedSchema.parse(res.data)
   })
 })

--- a/test/rpc.test.ts
+++ b/test/rpc.test.ts
@@ -2,6 +2,7 @@ import { PostgrestClient } from '../src/index'
 import { Database } from './types.override'
 import { expectType } from 'tsd'
 import { TypeEqual } from 'ts-expect'
+import { z } from 'zod'
 
 const REST_URL = 'http://localhost:3000'
 export const postgrest = new PostgrestClient<Database>(REST_URL)
@@ -26,8 +27,15 @@ test('RPC call with no params', async () => {
   `)
   // check our result types match the runtime result
   let result: Exclude<typeof res.data, null>
-  let expected: Database['public']['Functions'][typeof RPC_NAME]['Returns']
+  const ExpectedSchema = z.array(
+    z.object({
+      status: z.enum(['ONLINE', 'OFFLINE'] as const),
+      username: z.string(),
+    })
+  )
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('RPC call with star select', async () => {
@@ -48,8 +56,15 @@ test('RPC call with star select', async () => {
   `)
   // check our result types match the runtime result
   let result: Exclude<typeof res.data, null>
-  let expected: Database['public']['Functions'][typeof RPC_NAME]['Returns']
+  const ExpectedSchema = z.array(
+    z.object({
+      status: z.enum(['ONLINE', 'OFFLINE'] as const),
+      username: z.string(),
+    })
+  )
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('RPC call with single field select', async () => {
@@ -69,8 +84,14 @@ test('RPC call with single field select', async () => {
   `)
   // check our result types match the runtime result
   let result: Exclude<typeof res.data, null>
-  let expected: { username: string }[]
+  const ExpectedSchema = z.array(
+    z.object({
+      username: z.string(),
+    })
+  )
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('RPC call with multiple fields select', async () => {
@@ -91,8 +112,15 @@ test('RPC call with multiple fields select', async () => {
   `)
   // check our result types match the runtime result
   let result: Exclude<typeof res.data, null>
-  let expected: Database['public']['Functions'][typeof RPC_NAME]['Returns']
+  const ExpectedSchema = z.array(
+    z.object({
+      status: z.enum(['ONLINE', 'OFFLINE'] as const),
+      username: z.string(),
+    })
+  )
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('RPC call with field aliasing', async () => {
@@ -112,8 +140,14 @@ test('RPC call with field aliasing', async () => {
   `)
   // check our result types match the runtime result
   let result: Exclude<typeof res.data, null>
-  let expected: { name: string }[]
+  const ExpectedSchema = z.array(
+    z.object({
+      name: z.string(),
+    })
+  )
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('RPC call with field casting', async () => {
@@ -133,8 +167,14 @@ test('RPC call with field casting', async () => {
   `)
   // check our result types match the runtime result
   let result: Exclude<typeof res.data, null>
-  let expected: { status: string }[]
+  const ExpectedSchema = z.array(
+    z.object({
+      status: z.string(),
+    })
+  )
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })
 
 test('RPC call with field aggregate', async () => {
@@ -157,6 +197,13 @@ test('RPC call with field aggregate', async () => {
   `)
   // check our result types match the runtime result
   let result: Exclude<typeof res.data, null>
-  let expected: { count: number; status: 'ONLINE' | 'OFFLINE' }[]
+  const ExpectedSchema = z.array(
+    z.object({
+      count: z.number(),
+      status: z.enum(['ONLINE', 'OFFLINE'] as const),
+    })
+  )
+  let expected: z.infer<typeof ExpectedSchema>
   expectType<TypeEqual<typeof result, typeof expected>>(true)
+  ExpectedSchema.parse(res.data)
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Continue work started in: https://github.com/supabase/postgrest-js/pull/627 and leverage zod schema for runtime types shapes validations and type check tests on more tests.