### PR TITLE
chore: add preview release

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,36 @@
+name: Preview release
+
+permissions:
+  pull-requests: write
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, labeled]
+
+jobs:
+  preview:
+    if: >
+      github.repository == 'supabase/postgrest-js' &&
+      (github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger: preview')))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - run: npx pkg-pr-new@latest publish --compact

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build](https://github.com/supabase/postgrest-js/workflows/CI/badge.svg)](https://github.com/supabase/postgrest-js/actions?query=branch%3Amaster)
 [![Package](https://img.shields.io/npm/v/@supabase/postgrest-js)](https://www.npmjs.com/package/@supabase/postgrest-js)
 [![License: MIT](https://img.shields.io/npm/l/@supabase/postgrest-js)](#license)
+[![pkg.pr.new](https://pkg.pr.new/badge/supabase/postgrest-js)](https://pkg.pr.new/~/supabase/postgrest-js)
+
 
 Isomorphic JavaScript client for [PostgREST](https://postgrest.org). The goal of this library is to make an "ORM-like" restful interface.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Infrastructure improvement - adds a preview release workflow for easier testing of changes.

## What is the current behavior?

Contributors and maintainers need to manually build and test changes locally or wait for official releases to test package changes.

## What is the new behavior?

- Adds automated preview release workflow using [`pkg.pr.new`](https://github.com/stackblitz-labs/pkg.pr.new)
- Triggers on pushes to `master` branch and PRs with the `trigger: preview` label
- Automatically publishes preview packages that can be installed and tested
- Provides temporary package URLs for quick testing without affecting the main package

## Additional context

This workflow allows for:
- Quick testing of PR changes before merging
- Easy collaboration on features by sharing preview package links
- Reduced friction in the development and review process

The workflow uses the `trigger: preview` label to control when preview releases are created for PRs, preventing unnecessary builds while allowing on-demand testing.