### PR TITLE
Feat/expose query builder options

### DIFF
--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -1,6 +1,7 @@
 import PostgrestQueryBuilder from './PostgrestQueryBuilder'
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
-import { Fetch, GenericSchema, ClientServerOptions } from './types'
+import { Fetch, GenericSchema, ClientServerOptions, PostgrestQueryBuilderOptions, PostgrestQueryBuilderOptionsWithSchema } from './types'
+import { mergeHeaders } from './utils'
 
 /**
  * PostgREST client.
@@ -54,11 +55,7 @@ export default class PostgrestClient<
       headers = {},
       schema,
       fetch,
-    }: {
-      headers?: HeadersInit
-      schema?: SchemaName
-      fetch?: Fetch
-    } = {}
+    }: PostgrestQueryBuilderOptionsWithSchema<SchemaName> = {}
   ) {
     this.url = url
     this.headers = new Headers(headers)
@@ -68,21 +65,26 @@ export default class PostgrestClient<
   from<
     TableName extends string & keyof Schema['Tables'],
     Table extends Schema['Tables'][TableName]
-  >(relation: TableName): PostgrestQueryBuilder<ClientOptions, Schema, Table, TableName>
+  >(
+    relation: TableName,
+    options?: PostgrestQueryBuilderOptions
+  ): PostgrestQueryBuilder<ClientOptions, Schema, Table, TableName>
   from<ViewName extends string & keyof Schema['Views'], View extends Schema['Views'][ViewName]>(
-    relation: ViewName
+    relation: ViewName,
+    options?: PostgrestQueryBuilderOptions
   ): PostgrestQueryBuilder<ClientOptions, Schema, View, ViewName>
   /**
    * Perform a query on a table or a view.
    *
    * @param relation - The table or view name to query
    */
-  from(relation: string): PostgrestQueryBuilder<ClientOptions, Schema, any, any> {
+  from(relation: string, options?: PostgrestQueryBuilderOptions): PostgrestQueryBuilder<ClientOptions, Schema, any, any> {
     const url = new URL(`${this.url}/${relation}`)
+
     return new PostgrestQueryBuilder(url, {
-      headers: new Headers(this.headers),
+      headers: mergeHeaders(this.headers, options?.headers),
       schema: this.schemaName,
-      fetch: this.fetch,
+      fetch: options?.fetch ?? this.fetch,
     })
   }
 

--- a/src/PostgrestClient.ts
+++ b/src/PostgrestClient.ts
@@ -1,6 +1,12 @@
 import PostgrestQueryBuilder from './PostgrestQueryBuilder'
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
-import { Fetch, GenericSchema, ClientServerOptions, PostgrestQueryBuilderOptions, PostgrestQueryBuilderOptionsWithSchema } from './types'
+import {
+  Fetch,
+  GenericSchema,
+  ClientServerOptions,
+  PostgrestQueryBuilderOptions,
+  PostgrestQueryBuilderOptionsWithSchema,
+} from './types'
 import { mergeHeaders } from './utils'
 
 /**
@@ -51,11 +57,7 @@ export default class PostgrestClient<
    */
   constructor(
     url: string,
-    {
-      headers = {},
-      schema,
-      fetch,
-    }: PostgrestQueryBuilderOptionsWithSchema<SchemaName> = {}
+    { headers = {}, schema, fetch }: PostgrestQueryBuilderOptionsWithSchema<SchemaName> = {}
   ) {
     this.url = url
     this.headers = new Headers(headers)
@@ -78,7 +80,10 @@ export default class PostgrestClient<
    *
    * @param relation - The table or view name to query
    */
-  from(relation: string, options?: PostgrestQueryBuilderOptions): PostgrestQueryBuilder<ClientOptions, Schema, any, any> {
+  from(
+    relation: string,
+    options?: PostgrestQueryBuilderOptions
+  ): PostgrestQueryBuilder<ClientOptions, Schema, any, any> {
     const url = new URL(`${this.url}/${relation}`)
 
     return new PostgrestQueryBuilder(url, {

--- a/src/PostgrestQueryBuilder.ts
+++ b/src/PostgrestQueryBuilder.ts
@@ -1,6 +1,13 @@
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 import { GetResult } from './select-query-parser/result'
-import { ClientServerOptions, Fetch, GenericSchema, GenericTable, GenericView, PostgrestQueryBuilderOptions, PostgrestQueryBuilderOptionsWithSchema } from './types'
+import {
+  ClientServerOptions,
+  Fetch,
+  GenericSchema,
+  GenericTable,
+  GenericView,
+  PostgrestQueryBuilderOptionsWithSchema,
+} from './types'
 
 export default class PostgrestQueryBuilder<
   ClientOptions extends ClientServerOptions,
@@ -17,11 +24,7 @@ export default class PostgrestQueryBuilder<
 
   constructor(
     url: URL,
-    {
-      headers = {},
-      schema,
-      fetch,
-    }: PostgrestQueryBuilderOptionsWithSchema<string>
+    { headers = {}, schema, fetch }: PostgrestQueryBuilderOptionsWithSchema<string>
   ) {
     this.url = url
     this.headers = new Headers(headers)

--- a/src/PostgrestQueryBuilder.ts
+++ b/src/PostgrestQueryBuilder.ts
@@ -1,6 +1,6 @@
 import PostgrestFilterBuilder from './PostgrestFilterBuilder'
 import { GetResult } from './select-query-parser/result'
-import { ClientServerOptions, Fetch, GenericSchema, GenericTable, GenericView } from './types'
+import { ClientServerOptions, Fetch, GenericSchema, GenericTable, GenericView, PostgrestQueryBuilderOptions, PostgrestQueryBuilderOptionsWithSchema } from './types'
 
 export default class PostgrestQueryBuilder<
   ClientOptions extends ClientServerOptions,
@@ -21,11 +21,7 @@ export default class PostgrestQueryBuilder<
       headers = {},
       schema,
       fetch,
-    }: {
-      headers?: HeadersInit
-      schema?: string
-      fetch?: Fetch
-    }
+    }: PostgrestQueryBuilderOptionsWithSchema<string>
   ) {
     this.url = url
     this.headers = new Headers(headers)

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ export type {
   PostgrestSingleResponse,
   PostgrestMaybeSingleResponse,
   ClientServerOptions as PostgrestClientOptions,
+  PostgrestQueryBuilderOptions,
+  PostgrestQueryBuilderOptionsWithSchema,
 } from './types'
 // https://github.com/supabase/postgrest-js/issues/551
 // To be replaced with a helper type that only uses public types

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,15 @@ export type PostgrestSingleResponse<T> = PostgrestResponseSuccess<T> | Postgrest
 export type PostgrestMaybeSingleResponse<T> = PostgrestSingleResponse<T | null>
 export type PostgrestResponse<T> = PostgrestSingleResponse<T[]>
 
+export type PostgrestQueryBuilderOptions = {
+  headers?: HeadersInit
+  fetch?: Fetch
+}
+
+export type PostgrestQueryBuilderOptionsWithSchema<TSchema extends string> = PostgrestQueryBuilderOptions & {
+  schema?: TSchema
+}
+
 export type GenericRelationship = {
   foreignKeyName: string
   columns: string[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,9 +36,10 @@ export type PostgrestQueryBuilderOptions = {
   fetch?: Fetch
 }
 
-export type PostgrestQueryBuilderOptionsWithSchema<TSchema extends string> = PostgrestQueryBuilderOptions & {
-  schema?: TSchema
-}
+export type PostgrestQueryBuilderOptionsWithSchema<TSchema extends string> =
+  PostgrestQueryBuilderOptions & {
+    schema?: TSchema
+  }
 
 export type GenericRelationship = {
   foreignKeyName: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,13 +6,18 @@
  */
 
 export function mergeHeaders(left: Headers, right?: HeadersInit): HeadersInit {
-    if (!right) return left;
+  if (!right) return left
 
-    const merged = new Headers(left);
-    const rightEntries = (right instanceof Headers) ? right.entries() : Array.isArray(right) ? right : Object.entries(right);
-    for (const [key, value] of rightEntries) {
-        merged.set(key, value);
-    }
+  const merged = new Headers(left)
+  const rightEntries =
+    right instanceof Headers
+      ? right.entries()
+      : Array.isArray(right)
+      ? right
+      : Object.entries(right)
+  for (const [key, value] of rightEntries) {
+    merged.set(key, value)
+  }
 
-    return merged;
+  return merged
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Non-destructively merges an optional {@link HeadersInit} into a {@link Headers} object, where {@link right} takes precedence over {@link left} if it exists.
+ * @param {Headers} left Base {@link Headers} object
+ * @param {HeadersInit?} right Optional {@link HeadersInit} to merge into {@link left}
+ * @returns The resulting merged {@link HeadersInit} object.
+ */
+
+export function mergeHeaders(left: Headers, right?: HeadersInit): HeadersInit {
+    if (!right) return left;
+
+    const merged = new Headers(left);
+    const rightEntries = (right instanceof Headers) ? right.entries() : Array.isArray(right) ? right : Object.entries(right);
+    for (const [key, value] of rightEntries) {
+        merged.set(key, value);
+    }
+
+    return merged;
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduces a way to pass options to the PostgrestQueryBuilder instance on a per-request basis.

## What is the current behavior?

There is no way to specify per-request options currently.
https://github.com/supabase/supabase-js/issues/438

## What is the new behavior?

An optional parameter is introduced that can be passed to the `.from` method, where users can optionally specify custom `fetch` and `headers` options.